### PR TITLE
Support inline tool scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ This file defines available tools.
 name: The name of the tool.
 description: A brief description of the tool.
 script: The content of the Python script that implements the tool. The script must define a function called run_tool(args) that takes a dictionary of arguments and returns a string.
+script_path: (optional) Path to a Python file containing the tool implementation. If script_path is missing but script is provided, the application will run the script from a temporary file.
 Example:
 
 '''JSON


### PR DESCRIPTION
## Summary
- support running tools defined directly in `tools.json`
- store script contents alongside script path
- document optional `script_path` field and temporary script handling

## Testing
- `python3 -m py_compile tools.py dialogs.py tab_tools.py app.py message_broker.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9841feb88326874013438c9fbe09