### PR TITLE
Fix chat send tooltip text

### DIFF
--- a/tab_chat.py
+++ b/tab_chat.py
@@ -145,7 +145,7 @@ class ChatTab(QWidget):
         self.send_button = QPushButton("Send")
         self.send_button.setObjectName("sendButton")
         self.send_button.setIcon(self.style().standardIcon(getattr(QStyle, 'SP_ArrowRight')))
-        self.send_button.setToolTip("Send the message (Ctrl+Enter)")
+        self.send_button.setToolTip("Send the message (Enter)")
         btn_layout.addWidget(self.send_button)
         
         # Create clear button


### PR DESCRIPTION
## Summary
- update tooltip hint to match actual Enter key behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f984988fc8326b9048c2b8da32219