### PR TITLE
Add desktop screenshot capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Agents can schedule tasks to be executed at a specific time.
     *   Tasks are stored in `tasks.json`.
 *   **Desktop History:**
-    *   Agents can be granted access to screenshots of the user's desktop.
-    *   Currently, this feature is not implemented, but the groundwork has been laid.
+    *   Agents with `desktop_history_enabled` set to true will receive recent screenshots
+        of your desktop. The capture interval is controlled by `screenshot_interval`.
 *   **Customizable UI:**
     *   Light and dark mode support.
     *   Configurable user name and color.
@@ -103,8 +103,8 @@ This file stores the configuration for each agent.
 *   **`role`:** Defines the agent's role: "Coordinator", "Assistant", or "Specialist".
 *   **`description`:** A brief description of the agent's capabilities (used by Coordinators).
 *   **`managed_agents`:** (Coordinator only) A list of agents managed by this Coordinator.
-*   **`desktop_history_enabled`:** Enables access to desktop screenshots (currently not implemented).
-*   **`screenshot_interval`:**  Sets the screenshot interval (currently not implemented).
+*   **`desktop_history_enabled`:** Enables access to desktop screenshots.
+*   **`screenshot_interval`:**  Interval in seconds between captured screenshots.
 *   **`tool_use`:** Boolean value to enable or disable an agent's access to tools.
 *   **`tools_enabled`:** A list of tools that an agent can access, assuming `tool_use` is set to true.
 
@@ -144,7 +144,7 @@ This file stores global application settings.
 
 debug_enabled: Enables debug mode (boolean).
 include_image: Currently unused.
-include_screenshot: Currently unused.
+include_screenshot: Deprecated.
 image_path: Currently unused.
 user_name: The user's display name.
 user_color: The user's chat message color.

--- a/screenshot.py
+++ b/screenshot.py
@@ -1,0 +1,49 @@
+"""Screenshot capture utilities."""
+
+import os
+from datetime import datetime
+from PyQt5.QtCore import QObject, QTimer
+from PyQt5.QtGui import QGuiApplication
+
+
+class ScreenshotManager(QObject):
+    """Periodically capture screenshots of the primary screen."""
+
+    def __init__(self, output_dir="screenshots", interval=5, max_images=10, parent=None):
+        super().__init__(parent)
+        self.output_dir = output_dir
+        self.interval = interval
+        self.max_images = max_images
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.capture)
+        self.images = []
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def start(self, interval=None):
+        """Start capturing screenshots."""
+        if interval:
+            self.interval = interval
+        self.timer.start(int(self.interval * 1000))
+
+    def stop(self):
+        """Stop capturing screenshots."""
+        self.timer.stop()
+
+    def capture(self):
+        """Capture the current screen and store the file path."""
+        screen = QGuiApplication.primaryScreen()
+        if not screen:
+            return None
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        path = os.path.join(self.output_dir, f"screenshot_{timestamp}.png")
+        pixmap = screen.grabWindow(0)
+        if pixmap.save(path, "png"):
+            self.images.append(path)
+            if len(self.images) > self.max_images:
+                self.images.pop(0)
+            return path
+        return None
+
+    def get_images(self):
+        """Return list of recently captured images."""
+        return list(self.images)


### PR DESCRIPTION
## Summary
- add `ScreenshotManager` to capture desktop images at intervals
- include screenshots in agent chat history when `desktop_history_enabled` is true
- start screenshot timer based on agent settings
- document screenshot usage in README

## Testing
- `pip install -q -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa65619f8832693a59f570aaba2ce