### PR TITLE
Add persistent chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Task Scheduling:**
     *   Agents can schedule tasks to be executed at a specific time.
     *   Tasks are stored in `tasks.json`.
+*   **Chat History Persistence:**
+    *   Conversations are saved to `chat_history.json` for each session.
+    *   History can be exported or cleared from the chat menu.
 *   **Desktop History:**
     *   Agents can be granted access to screenshots of the user's desktop.
     *   Currently, this feature is not implemented, but the groundwork has been laid.

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from PyQt5.QtGui import QKeySequence
 from worker import AIWorker
 from tools import load_tools, run_tool
 from tasks import load_tasks, save_tasks, add_task, delete_task
+from transcripts import load_history, append_message, clear_history, export_history
 from tab_chat import ChatTab
 from tab_agents import AgentsTab
 from tab_tools import ToolsTab
@@ -39,7 +40,7 @@ class AIChatApp(QMainWindow):
         self.setGeometry(100, 100, 1000, 700)  # Larger default window
 
         # Variables
-        self.chat_history = []
+        self.chat_history = load_history(self.debug_enabled)
         self.current_responses = {}
         self.agents_data = {}
         self.include_image = False
@@ -407,6 +408,7 @@ class AIChatApp(QMainWindow):
 
         user_message = {"role": "user", "content": user_text}
         self.chat_history.append(user_message)
+        append_message(self.chat_history, "user", user_text, debug_enabled=self.debug_enabled)
 
         # If a Coordinator agent is enabled, send the message to the Coordinator agents only.
         enabled_coordinator_agents = [
@@ -484,6 +486,19 @@ class AIChatApp(QMainWindow):
         self.chat_tab.chat_display.clear()
         self.chat_history = []
         self.show_notification("Chat cleared")
+
+    def clear_chat_histories(self):
+        """Clear persisted chat history from disk."""
+        clear_history(self.debug_enabled)
+        self.chat_history = []
+        self.show_notification("Stored history cleared")
+
+    def export_chat_histories(self):
+        """Export persisted chat history to a timestamped file."""
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        dest = f"chat_history_export_{ts}.json"
+        export_history(dest, self.debug_enabled)
+        self.show_notification(f"History exported to {dest}")
 
     def handle_ai_response_chunk(self, chunk, agent_name):
         if agent_name not in self.current_responses:
@@ -597,6 +612,7 @@ class AIChatApp(QMainWindow):
                 
                 # Store only the clean content without thoughts in history
                 self.chat_history.append({"role": "assistant", "content": clean_content, "agent": agent_name})
+                append_message(self.chat_history, "assistant", clean_content, agent_name, debug_enabled=self.debug_enabled)
         
         # Display the message from a Specialist if specified by Coordinator
         elif agent_settings.get('role') == 'Specialist' and any(msg['content'].strip().endswith(f"Next Response By: {agent_name}") for msg in self.chat_history):
@@ -625,6 +641,7 @@ class AIChatApp(QMainWindow):
             
             # Store only the clean content without thoughts in history
             self.chat_history.append({"role": "assistant", "content": clean_content, "agent": agent_name})
+            append_message(self.chat_history, "assistant", clean_content, agent_name, debug_enabled=self.debug_enabled)
 
         # If there's a next agent specified and it's managed by the Coordinator, process it.
         if next_agent:
@@ -655,6 +672,7 @@ class AIChatApp(QMainWindow):
                 error_msg = f"[{timestamp}] <span style='color:red;'>[Tool Error] Tool '{tool_name}' is not enabled for agent '{agent_name}'.</span>"
                 self.chat_tab.append_message_html(error_msg)
                 self.chat_history.append({"role": "assistant", "content": error_msg, "agent": agent_name})
+                append_message(self.chat_history, "assistant", error_msg, agent_name, debug_enabled=self.debug_enabled)
                 self.show_notification(f"Tool Error: '{tool_name}' not enabled for agent", "error")
             else:
                 self.show_notification(f"Agent '{agent_name}' is using tool: {tool_name}", "info")
@@ -666,11 +684,13 @@ class AIChatApp(QMainWindow):
                     self.chat_tab.append_message_html(error_msg)
                     # Append error message to chat history
                     self.chat_history.append({"role": "assistant", "content": error_msg, "agent": agent_name})
+                    append_message(self.chat_history, "assistant", error_msg, agent_name, debug_enabled=self.debug_enabled)
                     self.show_notification(f"Tool Error: {tool_result}", "error")
                 else:
                     display_message = f"{agent_name} used {tool_name} with args {tool_args}\nTool Result: {tool_result}"
                     self.chat_tab.append_message_html(f"\n[{timestamp}] <span style='color:{agent_color};'>{display_message}</span>")
                     self.chat_history.append({"role": "assistant", "content": display_message, "agent": agent_name})
+                    append_message(self.chat_history, "assistant", display_message, agent_name, debug_enabled=self.debug_enabled)
                     self.show_notification(f"Tool executed successfully: {tool_name}", "info")
 
         # Handle task request if any
@@ -724,6 +744,7 @@ class AIChatApp(QMainWindow):
 
         # Add this message to the chat history
         self.chat_history.append({"role": "user", "content": formatted_message})
+        append_message(self.chat_history, "user", formatted_message, debug_enabled=self.debug_enabled)
 
         # Find the agent settings
         agent_settings = self.agents_data.get(agent_name, {})
@@ -945,6 +966,9 @@ class AIChatApp(QMainWindow):
     # Chat History Helpers
     # -------------------------------------------------------------------------
     def build_agent_chat_history(self, agent_name, user_message=None, is_screenshot=False):
+        # Reload history from disk to ensure persistence
+        self.chat_history = load_history(self.debug_enabled)
+
         system_prompt = ""
         agent_settings = self.agents_data.get(agent_name, {})
 

--- a/tab_chat.py
+++ b/tab_chat.py
@@ -71,6 +71,14 @@ class ChatTab(QWidget):
         clear_action = QAction("Clear conversation", self)
         clear_action.triggered.connect(self.on_clear_chat_clicked)
         options_menu.addAction(clear_action)
+
+        export_hist_action = QAction("Export history", self)
+        export_hist_action.triggered.connect(self.parent_app.export_chat_histories)
+        options_menu.addAction(export_hist_action)
+
+        clear_hist_action = QAction("Clear saved history", self)
+        clear_hist_action.triggered.connect(self.parent_app.clear_chat_histories)
+        options_menu.addAction(clear_hist_action)
         
         options_btn.setMenu(options_menu)
         options_btn.setPopupMode(QToolButton.InstantPopup)

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -1,0 +1,15 @@
+import transcripts
+
+
+def noop_save(history, debug_enabled=False):
+    pass
+
+
+def test_append_message(monkeypatch):
+    history = []
+    monkeypatch.setattr(transcripts, "save_history", noop_save)
+    entry = transcripts.append_message(history, "assistant", "hi", "agent1")
+    assert history[0]["content"] == "hi"
+    assert history[0]["agent"] == "agent1"
+    assert entry["role"] == "assistant"
+    assert "timestamp" in entry

--- a/transcripts.py
+++ b/transcripts.py
@@ -1,0 +1,65 @@
+# transcripts.py
+
+import json
+import os
+from datetime import datetime
+
+HISTORY_FILE = "chat_history.json"
+
+def load_history(debug_enabled=False):
+    """Load chat history from disk."""
+    if not os.path.exists(HISTORY_FILE):
+        return []
+    try:
+        with open(HISTORY_FILE, "r") as f:
+            data = json.load(f)
+        if debug_enabled:
+            print("[Debug] History loaded", data)
+        return data
+    except Exception as e:
+        print(f"[Error] Failed to load history: {e}")
+        return []
+
+def save_history(history, debug_enabled=False):
+    """Save chat history to disk."""
+    try:
+        with open(HISTORY_FILE, "w") as f:
+            json.dump(history, f, indent=2)
+        if debug_enabled:
+            print("[Debug] History saved")
+    except Exception as e:
+        print(f"[Error] Failed to save history: {e}")
+
+def append_message(history, role, content, agent=None, debug_enabled=False):
+    """Append a message to history and save it."""
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "role": role,
+        "content": content,
+    }
+    if agent:
+        entry["agent"] = agent
+    history.append(entry)
+    save_history(history, debug_enabled)
+    return entry
+
+def clear_history(debug_enabled=False):
+    """Delete the saved history file."""
+    try:
+        if os.path.exists(HISTORY_FILE):
+            os.remove(HISTORY_FILE)
+            if debug_enabled:
+                print("[Debug] History cleared")
+    except Exception as e:
+        print(f"[Error] Failed to clear history: {e}")
+
+def export_history(dest_path, debug_enabled=False):
+    """Export current history to the given path."""
+    history = load_history(debug_enabled)
+    try:
+        with open(dest_path, "w") as f:
+            json.dump(history, f, indent=2)
+        if debug_enabled:
+            print(f"[Debug] History exported to {dest_path}")
+    except Exception as e:
+        print(f"[Error] Failed to export history: {e}")


### PR DESCRIPTION
## Summary
- persist conversation data to `chat_history.json`
- load conversation history on start
- allow exporting or clearing saved history via UI
- update message broker for persistence
- add tests for transcript utilities

## Testing
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa65b71148326834a1ddcecce15de