### PR TITLE
Add calendar view for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Task Scheduling:**
     *   Agents can schedule tasks to be executed at a specific time.
     *   Tasks are stored in `tasks.json`.
+    *   Tasks appear on a drag-and-drop calendar for easy rescheduling and completion.
 *   **Chat History Persistence:**
     *   Conversations are saved to `chat_history.json` for each session.
     *   History can be exported or cleared from the chat menu.

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -2,11 +2,57 @@
 
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QListWidget, QHBoxLayout, QPushButton, QListWidgetItem,
-    QLabel, QMessageBox, QDialog, QStyle, QAbstractItemView
+    QLabel, QMessageBox, QDialog, QStyle, QAbstractItemView, QCalendarWidget,
+    QInputDialog
 )
-from PyQt5.QtCore import Qt  # Import Qt from PyQt5.QtCore
+from PyQt5.QtCore import Qt, QDate, QDateTime  # Import Qt from PyQt5.QtCore
+from PyQt5.QtGui import QDrag, QMimeData, QTextCharFormat, QBrush, QColor
 from dialogs import TaskDialog
-from tasks import add_task, edit_task, delete_task, set_task_status
+from tasks import (
+    add_task,
+    edit_task,
+    delete_task,
+    set_task_status,
+    update_task_due_time,
+)
+
+
+class TaskListWidget(QListWidget):
+    """List widget that starts drags with the task ID."""
+
+    def startDrag(self, supported_actions):
+        item = self.currentItem()
+        if not item:
+            return
+        mime = QMimeData()
+        mime.setText(item.data(Qt.UserRole))
+        drag = QDrag(self)
+        drag.setMimeData(mime)
+        drag.exec_(Qt.MoveAction)
+
+
+class DroppableCalendarWidget(QCalendarWidget):
+    """Calendar widget that accepts drops to reschedule tasks."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasText():
+            event.acceptProposedAction()
+
+    def dragMoveEvent(self, event):
+        if event.mimeData().hasText():
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        task_id = event.mimeData().text()
+        date = self.selectedDate()
+        parent = self.parent()
+        if hasattr(parent, "reschedule_task"):
+            parent.reschedule_task(task_id, date)
+        event.acceptProposedAction()
 
 class TasksTab(QWidget):
     """
@@ -22,10 +68,17 @@ class TasksTab(QWidget):
         self.setLayout(self.layout)
 
         # Tasks list
-        self.tasks_list = QListWidget()
-        self.tasks_list.setSelectionMode(QAbstractItemView.SingleSelection) # Enforce single selection
+        self.tasks_list = TaskListWidget()
+        self.tasks_list.setSelectionMode(QAbstractItemView.SingleSelection)  # Enforce single selection
+        self.tasks_list.setDragEnabled(True)
         self.tasks_list.itemSelectionChanged.connect(self.on_item_selection_changed)
+        self.tasks_list.itemDoubleClicked.connect(self.toggle_status_ui)
         self.layout.addWidget(self.tasks_list)
+
+        # Calendar view
+        self.calendar = DroppableCalendarWidget(self)
+        self.calendar.activated.connect(self.on_date_activated)
+        self.layout.addWidget(self.calendar)
 
         # Buttons
         btn_layout = QHBoxLayout()
@@ -61,6 +114,7 @@ class TasksTab(QWidget):
         self.status_button.clicked.connect(self.toggle_status_ui)
 
         self.refresh_tasks_list()
+        self.highlight_task_dates()
 
     def on_item_selection_changed(self):
         """
@@ -96,6 +150,23 @@ class TasksTab(QWidget):
                 item.setText(summary)
                 item.setData(Qt.UserRole, t['id'])  # Store the task ID in the item's data
                 self.tasks_list.addItem(item)
+        self.highlight_task_dates()
+
+    def highlight_task_dates(self):
+        """Highlight dates on the calendar that have tasks."""
+        fmt_default = QTextCharFormat()
+        self.calendar.setDateTextFormat(QDate(), fmt_default)  # clear all
+        highlighted = QTextCharFormat()
+        highlighted.setBackground(QBrush(QColor("#a0c5ff")))
+        for task in self.tasks:
+            due = task.get("due_time")
+            if not due:
+                continue
+            dt = QDateTime.fromString(due, Qt.ISODate)
+            if not dt.isValid():
+                dt = QDateTime.fromString(due, "yyyy-MM-dd HH:mm:ss")
+            if dt.isValid():
+                self.calendar.setDateTextFormat(dt.date(), highlighted)
 
     def add_task_ui(self):
         """
@@ -201,3 +272,56 @@ class TasksTab(QWidget):
             QMessageBox.warning(self, "Error Updating Status", err)
         else:
             self.refresh_tasks_list()
+
+    def on_date_activated(self, qdate):
+        """Ask to mark tasks on the activated date as completed."""
+        tasks_on_date = [t for t in self.tasks if self._task_date(t) == qdate]
+        if not tasks_on_date:
+            return
+        reply = QMessageBox.question(
+            self,
+            "Mark Complete",
+            f"Mark {len(tasks_on_date)} task(s) on {qdate.toString()} as completed?",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            for t in tasks_on_date:
+                set_task_status(
+                    self.tasks,
+                    t["id"],
+                    "completed",
+                    debug_enabled=self.parent_app.debug_enabled,
+                )
+            self.refresh_tasks_list()
+
+    def reschedule_task(self, task_id, qdate):
+        """Reschedule the given task to the selected date."""
+        task = next((t for t in self.tasks if t["id"] == task_id), None)
+        if not task:
+            return
+        due = task.get("due_time", "")
+        dt = QDateTime.fromString(due, Qt.ISODate)
+        if not dt.isValid():
+            dt = QDateTime.fromString(due, "yyyy-MM-dd HH:mm:ss")
+        if not dt.isValid():
+            dt = QDateTime(qdate, QDateTime.currentDateTime().time())
+        else:
+            dt.setDate(qdate)
+        new_due = dt.toString(Qt.ISODate)
+        update_task_due_time(
+            self.tasks,
+            task_id,
+            new_due,
+            debug_enabled=self.parent_app.debug_enabled,
+        )
+        self.refresh_tasks_list()
+
+    @staticmethod
+    def _task_date(task):
+        due = task.get("due_time")
+        if not due:
+            return QDate()
+        dt = QDateTime.fromString(due, Qt.ISODate)
+        if not dt.isValid():
+            dt = QDateTime.fromString(due, "yyyy-MM-dd HH:mm:ss")
+        return dt.date() if dt.isValid() else QDate()

--- a/tasks.py
+++ b/tasks.py
@@ -79,3 +79,12 @@ def set_task_status(tasks, task_id, status, debug_enabled=False):
     task["status"] = status
     save_tasks(tasks, debug_enabled)
     return None
+
+def update_task_due_time(tasks, task_id, due_time, debug_enabled=False):
+    """Update the due time for a task."""
+    task = next((t for t in tasks if t["id"] == task_id), None)
+    if not task:
+        return f"[Task Error] Task '{task_id}' not found."
+    task["due_time"] = due_time
+    save_tasks(tasks, debug_enabled)
+    return None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -70,3 +70,19 @@ def test_set_task_status_missing(monkeypatch):
     monkeypatch.setattr(tasks, "save_tasks", noop_save)
     err = tasks.set_task_status(task_list, "missing", "completed")
     assert err == "[Task Error] Task 'missing' not found."
+
+
+def test_update_task_due_time(monkeypatch):
+    task_list = []
+    monkeypatch.setattr(tasks, "save_tasks", noop_save)
+    task_id = tasks.add_task(task_list, "agent1", "do work", "2024-01-01 10:00")
+    err = tasks.update_task_due_time(task_list, task_id, "2024-03-01 09:00")
+    assert err is None
+    assert task_list[0]["due_time"] == "2024-03-01 09:00"
+
+
+def test_update_task_due_time_missing(monkeypatch):
+    task_list = []
+    monkeypatch.setattr(tasks, "save_tasks", noop_save)
+    err = tasks.update_task_due_time(task_list, "missing", "2024-03-01 09:00")
+    assert err == "[Task Error] Task 'missing' not found."


### PR DESCRIPTION
## Summary
- extend task scheduler with new `update_task_due_time`
- show tasks in a draggable calendar in `TasksTab`
- allow dropping tasks on dates to reschedule and double click to mark complete
- document the calendar feature in the README
- test new behaviour in `tests/test_tasks.py`

## Testing
- `pip install -q -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa9e9e7808326920c7ade8ee14abf