### PR TITLE
Add conversation summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Chat History Persistence:**
     *   Conversations are saved to `chat_history.json` for each session.
     *   History can be exported or cleared from the chat menu.
+*   **Conversation Summaries:**
+    *   Older messages are automatically condensed when a chat grows large to
+        keep prompts short.
 *   **Desktop History:**
     *   Agents with `desktop_history_enabled` set to true will receive recent screenshots
         of your desktop. The capture interval is controlled by `screenshot_interval`.

--- a/app.py
+++ b/app.py
@@ -16,7 +16,13 @@ from PyQt5.QtGui import QKeySequence
 from worker import AIWorker
 from tools import load_tools, run_tool
 from tasks import load_tasks, save_tasks, add_task, delete_task
-from transcripts import load_history, append_message, clear_history, export_history
+from transcripts import (
+    load_history,
+    append_message,
+    clear_history,
+    export_history,
+    summarize_history,
+)
 from tab_chat import ChatTab
 from tab_agents import AgentsTab
 from tab_tools import ToolsTab
@@ -43,6 +49,7 @@ class AIChatApp(QMainWindow):
 
         # Variables
         self.chat_history = load_history(self.debug_enabled)
+        self.chat_history = summarize_history(self.chat_history)
         self.current_responses = {}
         self.agents_data = {}
         self.include_image = False
@@ -985,6 +992,7 @@ class AIChatApp(QMainWindow):
     def build_agent_chat_history(self, agent_name, user_message=None, is_screenshot=False):
         # Reload history from disk to ensure persistence
         self.chat_history = load_history(self.debug_enabled)
+        self.chat_history = summarize_history(self.chat_history)
 
         system_prompt = ""
         agent_settings = self.agents_data.get(agent_name, {})

--- a/message_broker.py
+++ b/message_broker.py
@@ -5,7 +5,13 @@ from PyQt5.QtCore import QThread
 from worker import AIWorker
 from tools import run_tool
 from tasks import add_task, delete_task, save_tasks
-from transcripts import load_history, append_message, clear_history, export_history
+from transcripts import (
+    load_history,
+    append_message,
+    clear_history,
+    export_history,
+    summarize_history,
+)
 
 class MessageBroker:
     """
@@ -310,6 +316,7 @@ class MessageBroker:
             list: The chat history for the agent.
         """
         self.chat_history = load_history(self.app.debug_enabled if self.app else False)
+        self.chat_history = summarize_history(self.chat_history)
         system_prompt = ""
         agent_settings = self.app.agents_data.get(agent_name, {}) if self.app else {}
 

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -13,3 +13,14 @@ def test_append_message(monkeypatch):
     assert history[0]["agent"] == "agent1"
     assert entry["role"] == "assistant"
     assert "timestamp" in entry
+
+
+def test_summarize_history():
+    history = []
+    for i in range(30):
+        role = "user" if i % 2 == 0 else "assistant"
+        history.append({"role": role, "content": f"msg{i}", "agent": "a"})
+
+    summarized = transcripts.summarize_history(history, threshold=10)
+    assert summarized[0]["role"] == "system"
+    assert len(summarized) == 11

--- a/transcripts.py
+++ b/transcripts.py
@@ -63,3 +63,48 @@ def export_history(dest_path, debug_enabled=False):
             print(f"[Debug] History exported to {dest_path}")
     except Exception as e:
         print(f"[Error] Failed to export history: {e}")
+
+def summarize_history(history, threshold=20, max_chars=1000):
+    """Condense older history into a single system message.
+
+    If the number of messages exceeds ``threshold``, messages beyond the
+    threshold are concatenated and truncated to ``max_chars`` characters. The
+    condensed text is returned as a new system message prepended to the most
+    recent ``threshold`` messages.
+
+    Args:
+        history (list): Full chat history.
+        threshold (int, optional): Number of recent messages to keep. Defaults
+            to 20.
+        max_chars (int, optional): Maximum characters for the summary.
+
+    Returns:
+        list: Summarized chat history.
+    """
+    if len(history) <= threshold:
+        return history[:]
+
+    old_msgs = history[:-threshold]
+    recent = history[-threshold:]
+
+    parts = []
+    for msg in old_msgs:
+        content = msg.get("content", "").strip()
+        if not content:
+            continue
+        if msg["role"] == "user":
+            parts.append(f"User: {content}")
+        else:
+            agent = msg.get("agent", "assistant")
+            parts.append(f"{agent}: {content}")
+
+    summary_text = " ".join(parts)
+    if len(summary_text) > max_chars:
+        summary_text = summary_text[:max_chars].rstrip() + "..."
+
+    summary_msg = {
+        "role": "system",
+        "content": f"Summary of earlier conversation: {summary_text}"
+    }
+
+    return [summary_msg] + recent


### PR DESCRIPTION
## Summary
- add summarize_history helper
- use summarize_history when loading history
- describe conversation summaries in README
- test summarize_history

## Testing
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa9bc30dc83269c467d7050d3fd50