### PR TITLE
Add plugin-based tool discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Agents can invoke tools by including a specific JSON format in their response.
     *   Each agent has an individual setting to toggle tool usage on or off.
     *   Each agent can enable or disable individual tools.
+    *   Tools can also be discovered automatically from the `tool_plugins` directory
+        or from packages exposing the `cerebro_tools` entry point.
 *   **Task Scheduling:**
     *   Agents can schedule tasks to be executed at a specific time.
     *   Tasks are stored in `tasks.json`.
@@ -159,6 +161,8 @@ name: The name of the tool.
 description: A brief description of the tool.
 script: The content of the Python script that implements the tool. The script must define a function called run_tool(args) that takes a dictionary of arguments and returns a string.
 script_path: (optional) Path to a Python file containing the tool implementation. If script_path is missing but script is provided, the application will run the script from a temporary file.
+Tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point
+are loaded automatically on startup.
 Example:
 
 '''JSON

--- a/tab_tools.py
+++ b/tab_tools.py
@@ -68,15 +68,16 @@ class ToolsTab(QWidget):
 
     def refresh_tools_list(self):
         self.tools_list.clear()
-        if not self.tools:  # Check if the list is empty
+        user_tools = [t for t in self.tools if 'plugin_module' not in t]
+        if not user_tools:
             label = QLabel("No tools available.")
             label.setAlignment(Qt.AlignCenter)
             self.layout.addWidget(label)
         else:
-            for t in self.tools:
+            for t in user_tools:
                 item = QListWidgetItem()
                 item.setText(f"{t['name']}: {t['description']}")
-                item.setData(Qt.UserRole, t['name'])  # Store the tool name in the item's data
+                item.setData(Qt.UserRole, t['name'])
                 self.tools_list.addItem(item)
 
     def add_tool_ui(self):

--- a/tool_plugins/echo_plugin.py
+++ b/tool_plugins/echo_plugin.py
@@ -1,0 +1,7 @@
+TOOL_METADATA = {
+    "name": "echo-plugin",
+    "description": "Echo back the provided arguments"
+}
+
+def run_tool(args):
+    return str(args)


### PR DESCRIPTION
## Summary
- support discovering tools from `tool_plugins` directory or entry points
- ignore plugin tools in the Tools tab
- document plugin support in README
- add sample `echo-plugin` implementation

## Testing
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faa02954083269f0623577b5103d9