### PR TITLE
Add agent metrics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Configurable user name and color.
 *   **Debug Mode:**
     *   Enables verbose logging for debugging purposes.
+*   **Metrics Dashboard:**
+    *   View tool usage frequency, completed tasks, and agent response times.
 
 ## Requirements
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 #app.py
 import os
 import json
+import time
 from datetime import datetime
 from PyQt5 import QtCore
 from PyQt5.QtCore import QThread, Qt, QTimer
@@ -21,6 +22,8 @@ from tab_chat import ChatTab
 from tab_agents import AgentsTab
 from tab_tools import ToolsTab
 from tab_tasks import TasksTab
+from tab_metrics import MetricsTab
+from metrics import load_metrics, record_tool_usage, record_response_time
 
 AGENTS_SAVE_FILE = "agents.json"
 SETTINGS_FILE = "settings.json"
@@ -60,9 +63,11 @@ class AIChatApp(QMainWindow):
         self.notification_timer.timeout.connect(self.process_notifications)
         self.notification_timer.start(3000)  # Check every 3 seconds
 
-        # Load Tools and Tasks
+        # Load Tools, Tasks, and Metrics
         self.tools = load_tools(self.debug_enabled)
         self.tasks = load_tasks(self.debug_enabled)
+        self.metrics = load_metrics(self.debug_enabled)
+        self.response_start_times = {}
         
         # Create main layout with sidebar
         central_widget = QWidget()
@@ -117,6 +122,10 @@ class AIChatApp(QMainWindow):
         # Tasks button
         self.nav_buttons["tasks"] = self.create_nav_button("Tasks", 3)
         sidebar_layout.addWidget(self.nav_buttons["tasks"])
+
+        # Metrics button
+        self.nav_buttons["metrics"] = self.create_nav_button("Metrics", 4)
+        sidebar_layout.addWidget(self.nav_buttons["metrics"])
         
         # Add stretcher to push settings button to bottom
         sidebar_layout.addStretch(1)
@@ -146,12 +155,14 @@ class AIChatApp(QMainWindow):
         self.agents_tab = AgentsTab(self)
         self.tools_tab = ToolsTab(self)
         self.tasks_tab = TasksTab(self)
+        self.metrics_tab = MetricsTab(self)
         
         # Add pages to stacked widget
         self.content_stack.addWidget(self.chat_tab)
         self.content_stack.addWidget(self.agents_tab)
         self.content_stack.addWidget(self.tools_tab)
         self.content_stack.addWidget(self.tasks_tab)
+        self.content_stack.addWidget(self.metrics_tab)
         
         main_layout.addWidget(self.content_stack)
         
@@ -254,7 +265,7 @@ class AIChatApp(QMainWindow):
     def setup_keyboard_shortcuts(self):
         """Set up keyboard shortcuts for navigation and actions."""
         # Tab navigation shortcuts
-        for i, key in enumerate(['1', '2', '3', '4']):
+        for i, key in enumerate(['1', '2', '3', '4', '5']):
             shortcut = QShortcut(f"Ctrl+{key}", self)
             shortcut.activated.connect(lambda idx=i: self.change_tab(idx, self.nav_buttons[list(self.nav_buttons.keys())[idx]]))
         
@@ -282,6 +293,7 @@ class AIChatApp(QMainWindow):
                               "Ctrl+2: Agents Tab\n"
                               "Ctrl+3: Tools Tab\n"
                               "Ctrl+4: Tasks Tab\n"
+                              "Ctrl+5: Metrics Tab\n"
                               "Ctrl+S: Send Message\n"
                               "Ctrl+L: Clear Chat\n"
                               "Ctrl+T: Toggle Theme\n"
@@ -481,6 +493,7 @@ class AIChatApp(QMainWindow):
 
             thread.started.connect(worker.run)
             thread.start()
+            self.response_start_times[worker] = time.time()
 
         process_next_agent(0)
 
@@ -681,6 +694,8 @@ class AIChatApp(QMainWindow):
             else:
                 self.show_notification(f"Agent '{agent_name}' is using tool: {tool_name}", "info")
                 tool_result = run_tool(self.tools, tool_name, tool_args, self.debug_enabled)
+                record_tool_usage(self.metrics, tool_name, self.debug_enabled)
+                self.refresh_metrics_display()
 
                 # Check for tool errors and handle them
                 if tool_result.startswith("[Tool Error]"):
@@ -721,6 +736,11 @@ class AIChatApp(QMainWindow):
 
         if self.debug_enabled and agent_name:
             print(f"[Debug] Worker for agent '{agent_name}' finished.")
+
+        if sender_worker in self.response_start_times:
+            elapsed = time.time() - self.response_start_times.pop(sender_worker)
+            record_response_time(self.metrics, agent_name, elapsed, self.debug_enabled)
+            self.refresh_metrics_display()
 
         thread.quit()
         thread.wait()
@@ -780,6 +800,7 @@ class AIChatApp(QMainWindow):
 
             thread.started.connect(worker.run)
             thread.start()
+            self.response_start_times[worker] = time.time()
         else:
             error_msg = f"[{timestamp}] <span style='color:red;'>[Error] Agent '{agent_name}' is not enabled.</span>"
             self.chat_tab.append_message_html(error_msg)
@@ -910,6 +931,10 @@ class AIChatApp(QMainWindow):
             self.tools_tab.refresh_tools_list()
             self.show_notification("Tools list refreshed", "info")
 
+    def refresh_metrics_display(self):
+        if hasattr(self.metrics_tab, "refresh_metrics"):
+            self.metrics_tab.refresh_metrics()
+
     # -------------------------------------------------------------------------
     # Tasks / Scheduling
     # -------------------------------------------------------------------------
@@ -978,6 +1003,7 @@ class AIChatApp(QMainWindow):
 
         thread.started.connect(worker.run)
         thread.start()
+        self.response_start_times[worker] = time.time()
 
     # -------------------------------------------------------------------------
     # Chat History Helpers

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,61 @@
+import json
+import os
+
+METRICS_FILE = "metrics.json"
+
+
+def load_metrics(debug_enabled=False):
+    """Load metrics from disk."""
+    if not os.path.exists(METRICS_FILE):
+        return {"tool_usage": {}, "task_completion_counts": {}, "response_times": {}}
+    try:
+        with open(METRICS_FILE, "r") as f:
+            data = json.load(f)
+        if debug_enabled:
+            print("[Debug] Metrics loaded", data)
+        return data
+    except Exception as e:
+        print(f"[Error] Failed to load metrics: {e}")
+        return {"tool_usage": {}, "task_completion_counts": {}, "response_times": {}}
+
+
+def save_metrics(metrics, debug_enabled=False):
+    """Save metrics to disk."""
+    try:
+        with open(METRICS_FILE, "w") as f:
+            json.dump(metrics, f, indent=2)
+        if debug_enabled:
+            print("[Debug] Metrics saved")
+    except Exception as e:
+        print(f"[Error] Failed to save metrics: {e}")
+
+
+def record_tool_usage(metrics, tool_name, debug_enabled=False):
+    """Increment usage count for a tool."""
+    metrics.setdefault("tool_usage", {})
+    metrics["tool_usage"][tool_name] = metrics["tool_usage"].get(tool_name, 0) + 1
+    save_metrics(metrics, debug_enabled)
+
+
+def record_task_completion(metrics, agent_name, debug_enabled=False):
+    """Increment completed task count for an agent."""
+    metrics.setdefault("task_completion_counts", {})
+    metrics["task_completion_counts"][agent_name] = metrics["task_completion_counts"].get(agent_name, 0) + 1
+    save_metrics(metrics, debug_enabled)
+
+
+def record_response_time(metrics, agent_name, elapsed, debug_enabled=False):
+    """Record response time for an agent."""
+    metrics.setdefault("response_times", {})
+    entry = metrics["response_times"].setdefault(agent_name, {"total_time": 0.0, "count": 0})
+    entry["total_time"] += elapsed
+    entry["count"] += 1
+    save_metrics(metrics, debug_enabled)
+
+
+def average_response_time(metrics, agent_name):
+    """Return the average response time for an agent."""
+    entry = metrics.get("response_times", {}).get(agent_name)
+    if entry and entry.get("count"):
+        return entry["total_time"] / entry["count"]
+    return 0.0

--- a/tab_metrics.py
+++ b/tab_metrics.py
@@ -1,0 +1,48 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel
+from metrics import average_response_time
+
+
+class MetricsTab(QWidget):
+    """Displays statistics about agent activity."""
+
+    def __init__(self, parent_app):
+        super().__init__()
+        self.parent_app = parent_app
+
+        self.layout = QVBoxLayout(self)
+        self.setLayout(self.layout)
+
+        self.tool_usage_label = QLabel()
+        self.task_completion_label = QLabel()
+        self.response_time_label = QLabel()
+
+        self.layout.addWidget(self.tool_usage_label)
+        self.layout.addWidget(self.task_completion_label)
+        self.layout.addWidget(self.response_time_label)
+
+        self.refresh_metrics()
+
+    def refresh_metrics(self):
+        metrics = self.parent_app.metrics
+
+        tool_lines = ["Tool Usage:"]
+        for name, count in metrics.get("tool_usage", {}).items():
+            tool_lines.append(f"- {name}: {count}")
+        if len(tool_lines) == 1:
+            tool_lines.append("None recorded")
+        self.tool_usage_label.setText("\n".join(tool_lines))
+
+        task_lines = ["Task Completions:"]
+        for agent, count in metrics.get("task_completion_counts", {}).items():
+            task_lines.append(f"- {agent}: {count}")
+        if len(task_lines) == 1:
+            task_lines.append("None recorded")
+        self.task_completion_label.setText("\n".join(task_lines))
+
+        resp_lines = ["Average Response Times:"]
+        for agent in metrics.get("response_times", {}).keys():
+            avg = average_response_time(metrics, agent)
+            resp_lines.append(f"- {agent}: {avg:.2f}s")
+        if len(resp_lines) == 1:
+            resp_lines.append("None recorded")
+        self.response_time_label.setText("\n".join(resp_lines))

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -200,4 +200,8 @@ class TasksTab(QWidget):
         if err:
             QMessageBox.warning(self, "Error Updating Status", err)
         else:
+            if new_status == "completed":
+                from metrics import record_task_completion
+                record_task_completion(self.parent_app.metrics, task.get("agent_name", "unknown"), self.parent_app.debug_enabled)
+                self.parent_app.refresh_metrics_display()
             self.refresh_tasks_list()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,30 @@
+import metrics
+
+
+def noop_save(data, debug_enabled=False):
+    pass
+
+
+def test_record_tool_usage(monkeypatch):
+    data = {"tool_usage": {}}
+    monkeypatch.setattr(metrics, "save_metrics", noop_save)
+    metrics.record_tool_usage(data, "tool1")
+    assert data["tool_usage"]["tool1"] == 1
+    metrics.record_tool_usage(data, "tool1")
+    assert data["tool_usage"]["tool1"] == 2
+
+
+def test_record_task_completion(monkeypatch):
+    data = {"task_completion_counts": {}}
+    monkeypatch.setattr(metrics, "save_metrics", noop_save)
+    metrics.record_task_completion(data, "agent1")
+    assert data["task_completion_counts"]["agent1"] == 1
+
+
+def test_record_response_time(monkeypatch):
+    data = {"response_times": {}}
+    monkeypatch.setattr(metrics, "save_metrics", noop_save)
+    metrics.record_response_time(data, "agent1", 2.0)
+    metrics.record_response_time(data, "agent1", 1.0)
+    avg = metrics.average_response_time(data, "agent1")
+    assert abs(avg - 1.5) < 0.01


### PR DESCRIPTION
## Summary
- track metrics for tool use, tasks completed and agent response times
- show stats in new Metrics tab
- record metrics during tool execution and when tasks complete
- expose new metrics via tests

## Testing
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faa226c0c8326ac2443d199a912d8