### PR TITLE
Add documentation tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Follow these guidelines when modifying the project.
 
 ## Documentation
 - Update `README.md` when behavior or configuration changes.
+- Keep `docs/user_guide.md` current with any new features.
 
 ## Pull Request
 - The PR summary should describe the change.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Enables verbose logging for debugging purposes.
 *   **Metrics Dashboard:**
     *   View tool usage frequency, completed tasks, and agent response times.
+*   **Documentation Tab:**
+    *   Browse the built-in user guide for all features.
+
+## In-App Documentation
+Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
 
 ## Requirements
 

--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from tab_agents import AgentsTab
 from tab_tools import ToolsTab
 from tab_tasks import TasksTab
 from tab_metrics import MetricsTab
+from tab_docs import DocumentationTab
 from metrics import load_metrics, record_tool_usage, record_response_time
 
 AGENTS_SAVE_FILE = "agents.json"
@@ -133,6 +134,10 @@ class AIChatApp(QMainWindow):
         # Metrics button
         self.nav_buttons["metrics"] = self.create_nav_button("Metrics", 4)
         sidebar_layout.addWidget(self.nav_buttons["metrics"])
+
+        # Docs button
+        self.nav_buttons["docs"] = self.create_nav_button("Docs", 5)
+        sidebar_layout.addWidget(self.nav_buttons["docs"])
         
         # Add stretcher to push settings button to bottom
         sidebar_layout.addStretch(1)
@@ -163,6 +168,7 @@ class AIChatApp(QMainWindow):
         self.tools_tab = ToolsTab(self)
         self.tasks_tab = TasksTab(self)
         self.metrics_tab = MetricsTab(self)
+        self.docs_tab = DocumentationTab(self)
         
         # Add pages to stacked widget
         self.content_stack.addWidget(self.chat_tab)
@@ -170,6 +176,7 @@ class AIChatApp(QMainWindow):
         self.content_stack.addWidget(self.tools_tab)
         self.content_stack.addWidget(self.tasks_tab)
         self.content_stack.addWidget(self.metrics_tab)
+        self.content_stack.addWidget(self.docs_tab)
         
         main_layout.addWidget(self.content_stack)
         
@@ -272,7 +279,7 @@ class AIChatApp(QMainWindow):
     def setup_keyboard_shortcuts(self):
         """Set up keyboard shortcuts for navigation and actions."""
         # Tab navigation shortcuts
-        for i, key in enumerate(['1', '2', '3', '4', '5']):
+        for i, key in enumerate(['1', '2', '3', '4', '5', '6']):
             shortcut = QShortcut(f"Ctrl+{key}", self)
             shortcut.activated.connect(lambda idx=i: self.change_tab(idx, self.nav_buttons[list(self.nav_buttons.keys())[idx]]))
         
@@ -291,6 +298,7 @@ class AIChatApp(QMainWindow):
                               "• Agents: Configure your AI assistants\n"
                               "• Tools: Manage tools for agents to use\n"
                               "• Tasks: Schedule future agent actions\n\n"
+                              "• Docs: View the built-in user guide\n\n"
                               "Press Ctrl+K to view keyboard shortcuts.")
     
     def show_keyboard_shortcuts(self):
@@ -301,6 +309,7 @@ class AIChatApp(QMainWindow):
                               "Ctrl+3: Tools Tab\n"
                               "Ctrl+4: Tasks Tab\n"
                               "Ctrl+5: Metrics Tab\n"
+                              "Ctrl+6: Docs Tab\n"
                               "Ctrl+S: Send Message\n"
                               "Ctrl+L: Clear Chat\n"
                               "Ctrl+T: Toggle Theme\n"

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,21 @@
+# Cerebro User Guide
+
+This guide describes the features available in Cerebro.
+
+## Chat Tab
+Interact with your agents in a conversational interface. Send messages, receive responses, and manage chat history.
+
+## Agents Tab
+Create, configure, and remove AI agents. Each agent can use different models and settings.
+
+## Tools Tab
+Manage the tools that agents can invoke. Add new tools or edit existing ones.
+
+## Tasks Tab
+Schedule tasks for agents and mark them complete using the calendar interface.
+
+## Metrics Tab
+View statistics about tool usage, task completions, and average response times.
+
+## Documentation Tab
+View this guide directly inside the application.

--- a/tab_docs.py
+++ b/tab_docs.py
@@ -1,0 +1,30 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QTextEdit
+import os
+
+
+class DocumentationTab(QWidget):
+    """Display application documentation from docs/user_guide.md."""
+
+    def __init__(self, parent_app):
+        super().__init__()
+        self.parent_app = parent_app
+
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+
+        self.doc_view = QTextEdit()
+        self.doc_view.setReadOnly(True)
+        layout.addWidget(self.doc_view)
+
+        self.load_documentation()
+
+    def load_documentation(self):
+        """Load the markdown documentation into the view."""
+        doc_path = os.path.join(os.path.dirname(__file__), "docs", "user_guide.md")
+        try:
+            with open(doc_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.doc_view.setMarkdown(content)
+        except Exception as exc:
+            self.doc_view.setPlainText(f"Failed to load documentation: {exc}")
+

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,9 @@
+import os
+
+
+def test_user_guide_exists():
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'docs', 'user_guide.md')
+    assert os.path.exists(path)
+    with open(path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    assert 'Cerebro User Guide' in content


### PR DESCRIPTION
## Summary
- create docs/user_guide.md with overview of each tab
- implement DocumentationTab to show the user guide in-app
- integrate new Docs tab into the main UI
- document the new feature in README
- require keeping docs/user_guide.md updated in AGENTS instructions
- add a test ensuring the user guide exists

## Testing
- `pip install -r requirements-dev.txt`
- `pip install PyQt5==5.15.9`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fad04aa3c8326b0695c12fe6b7c81