### PR TITLE
Add math solver plugin tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
 *   Python 3.7 or higher
 *   PyQt5
 *   Requests
+*   SymPy
 *   A running Ollama instance with the desired language models installed (see [Ollama](https://ollama.ai/))
 
 ## Installation
@@ -173,7 +174,7 @@ description: A brief description of the tool.
 script: The content of the Python script that implements the tool. The script must define a function called run_tool(args) that takes a dictionary of arguments and returns a string.
 script_path: (optional) Path to a Python file containing the tool implementation. If script_path is missing but script is provided, the application will run the script from a temporary file.
 Tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point
-are loaded automatically on startup.
+are loaded automatically on startup. Built-in plugins include `math-solver` for complex calculations.
 Example:
 
 '''JSON

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -9,7 +9,7 @@ Interact with your agents in a conversational interface. Send messages, receive 
 Create, configure, and remove AI agents. Each agent can use different models and settings.
 
 ## Tools Tab
-Manage the tools that agents can invoke. Add new tools or edit existing ones.
+Manage the tools that agents can invoke. Add new tools or edit existing ones. Built-in plugins include `math-solver` for solving equations.
 
 ## Tasks Tab
 Schedule tasks for agents and mark them complete using the calendar interface.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5
 requests
+sympy

--- a/tests/test_math_solver.py
+++ b/tests/test_math_solver.py
@@ -1,0 +1,15 @@
+import json
+from tool_plugins import math_solver
+
+
+def test_solve_expression():
+    result = math_solver.run_tool({"expression": "2+2*2"})
+    data = json.loads(result)
+    assert data["result"] == "6"
+
+
+def test_solve_equation():
+    result = math_solver.run_tool({"equation": "x+2=5"})
+    data = json.loads(result)
+    assert "solutions" in data
+    assert data["solutions"][0] == "3"

--- a/tool_plugins/math_solver.py
+++ b/tool_plugins/math_solver.py
@@ -1,0 +1,29 @@
+TOOL_METADATA = {
+    "name": "math-solver",
+    "description": "Solve mathematical expressions or equations using SymPy and return a JSON-formatted result."
+}
+
+import json
+
+
+def run_tool(args):
+    """Evaluate an expression or solve an equation."""
+    expression = args.get("expression")
+    equation = args.get("equation")
+    try:
+        from sympy import Eq, sympify, solve
+        from sympy.parsing.sympy_parser import parse_expr
+
+        if equation:
+            if "=" not in equation:
+                return json.dumps({"error": "Equation must contain '='"})
+            left, right = equation.split("=", 1)
+            eq = Eq(parse_expr(left), parse_expr(right))
+            solutions = solve(eq)
+            return json.dumps({"solutions": [str(s) for s in solutions]})
+        if expression:
+            result = sympify(expression)
+            return json.dumps({"result": str(result)})
+        return json.dumps({"error": "No expression or equation provided"})
+    except Exception as e:
+        return json.dumps({"error": str(e)})


### PR DESCRIPTION
## Summary
- add a new `math-solver` tool plugin for solving expressions and equations
- document the math solver in README and user guide
- install `sympy` via requirements
- provide unit tests for the new tool

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb5b03bc08326a986179401759a31