### PR TITLE
Add Windows notifier plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Agents can schedule tasks to be executed at a specific time.
     *   Tasks are stored in `tasks.json`.
     *   Tasks appear on a drag-and-drop calendar for easy rescheduling and completion.
+    *   The included **Windows Notifier** tool can display Windows 11 notifications when a scheduled task runs.
 *   **Chat History Persistence:**
     *   Conversations are saved to `chat_history.json` for each session.
     *   History can be exported or cleared from the chat menu.
@@ -56,6 +57,7 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
 *   Python 3.7 or higher
 *   PyQt5
 *   Requests
+*   win10toast (required for Windows notification support)
 *   A running Ollama instance with the desired language models installed (see [Ollama](https://ollama.ai/))
 
 ## Installation
@@ -184,6 +186,9 @@ Example:
     "script": "def run_tool(args):\\n  import os\\n  import sys\\n  from tasks import load_tasks, save_tasks, add_task\\n  # The agent will pass arguments like:\\n  # {\\n  # \\"agent_name\\": \\"Agent X\\",\\n  # \\"prompt\\": \\"some scheduled prompt\\",\\n  # \\"due_time\\": \\"2024-12-31T23:59:59\\"\\n  # }\\n  agent_name = args.get(\\"agent_name\\", \\"Default Agent\\")\\n  prompt = args.get(\\"prompt\\", \\"No prompt provided\\")\\n  due_time = args.get(\\"due_time\\", \\"\\")\\n  tasks = load_tasks(False) #\\n  # load current tasks\\n  if not due_time:\\n   return \\"[schedule-task Error] No due_time provided.\\"\\n  # Add the task, marking creator as 'agent' or 'user' as you prefer.\\n  add_task(tasks, agent_name, prompt, due_time, creator=\\"agent\\", debug_enabled=False)\\n  return f\\"Task scheduled: Agent '{agent_name}' at '{due_time}' with prompt '{prompt}'.\\""
   }
 ]
+The repository also provides a `windows-notifier` plugin that relies on the
+`win10toast` package to display a Windows 11 notification. Pair it with the
+`schedule-task` tool to create reminders or daily summaries.
 tasks.json
 This file stores the list of scheduled tasks. Each task entry includes an ``id``, ``creator``,
 ``agent_name``, ``prompt``, ``due_time`` and ``status`` field. The status field defaults to ``pending``.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -10,6 +10,7 @@ Create, configure, and remove AI agents. Each agent can use different models and
 
 ## Tools Tab
 Manage the tools that agents can invoke. Add new tools or edit existing ones.
+The **Windows Notifier** tool can be used to display Windows 11 notifications when triggered by a scheduled task.
 
 ## Tasks Tab
 Schedule tasks for agents and mark them complete using the calendar interface.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5
 requests
+win10toast

--- a/tool_plugins/windows_notifier.py
+++ b/tool_plugins/windows_notifier.py
@@ -1,0 +1,20 @@
+TOOL_METADATA = {
+    "name": "windows-notifier",
+    "description": "Send a Windows 11 notification using win10toast."
+}
+
+
+def run_tool(args):
+    """Display a Windows notification."""
+    title = args.get("title", "Cerebro")
+    message = args.get("message", "Notification from Cerebro")
+    try:
+        from win10toast import ToastNotifier
+    except Exception:
+        return "[windows-notifier Error] win10toast not installed."
+    try:
+        toaster = ToastNotifier()
+        toaster.show_toast(title, message, duration=5)
+        return "Notification sent"
+    except Exception as e:
+        return f"[windows-notifier Error] {e}"


### PR DESCRIPTION
## Summary
- add `windows-notifier` plugin for Windows 11 toast notifications
- document the plugin in README and user guide
- list `win10toast` in requirements

## Testing
- `pip install -r requirements-dev.txt`
- `pip install PyQt5 requests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb6aca6e88326a1115d2ebcbf162e