### PR TITLE
Add agent list and editor navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -855,12 +855,8 @@ class AIChatApp(QMainWindow):
             if self.debug_enabled:
                 print("[Debug] Default agent added.")
 
-        self.agents_tab.agent_selector.clear()
-        for agent_name in self.agents_data.keys():
-            self.agents_tab.agent_selector.addItem(agent_name)
-
-        if self.agents_tab.agent_selector.count() > 0:
-            self.agents_tab.load_agent_settings(self.agents_tab.agent_selector.currentText())
+        if hasattr(self.agents_tab, "refresh_agent_table"):
+            self.agents_tab.refresh_agent_table()
 
     def add_agent(self):
         from PyQt5.QtWidgets import QInputDialog
@@ -883,26 +879,27 @@ class AIChatApp(QMainWindow):
                     "tool_use": False,
                     "tools_enabled": []
                 }
-                self.agents_tab.agent_selector.addItem(agent_name)
                 self.save_agents()
                 if self.debug_enabled:
                     print(f"[Debug] Agent '{agent_name}' added.")
                 self.show_notification(f"Agent '{agent_name}' created successfully", "info")
+                if hasattr(self.agents_tab, "refresh_agent_table"):
+                    self.agents_tab.refresh_agent_table()
             else:
                 QMessageBox.warning(self, "Agent Exists", "Agent already exists.")
         self.update_send_button_state()
 
-    def delete_agent(self):
-        current_agent = self.agents_tab.agent_selector.currentText()
-        if current_agent:
-            if current_agent in self.agents_data:
-                del self.agents_data[current_agent]
-                idx = self.agents_tab.agent_selector.currentIndex()
-                self.agents_tab.agent_selector.removeItem(idx)
-                self.save_agents()
-                if self.debug_enabled:
-                    print(f"[Debug] Agent '{current_agent}' removed.")
-                self.show_notification(f"Agent '{current_agent}' deleted", "info")
+    def delete_agent(self, agent_name=None):
+        if agent_name is None:
+            agent_name = self.agents_tab.current_agent
+        if agent_name and agent_name in self.agents_data:
+            del self.agents_data[agent_name]
+            self.save_agents()
+            if self.debug_enabled:
+                print(f"[Debug] Agent '{agent_name}' removed.")
+            self.show_notification(f"Agent '{agent_name}' deleted", "info")
+            if hasattr(self.agents_tab, "refresh_agent_table"):
+                self.agents_tab.refresh_agent_table()
         self.update_send_button_state()
 
     def save_agents(self):

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -20,7 +20,10 @@ The Agents tab lets you create and configure AI agents. Every agent stores the f
 - **Tool Use** – allow the agent to call tools.
 - **Enabled Tools** – choose which tools are available when tool use is on.
 
-Changes are saved automatically when you modify a field. New agents can be added with **Add New Agent**. Select an existing agent and click **Delete Agent** to remove it.
+Changes are saved automatically when you modify a field. The Agents tab opens to
+a table listing all agents with an **Edit** button next to each one. Use
+**Add New Agent** to create a new entry. When editing an agent you can return to
+the list with **Back** or remove it with **Delete Agent**.
 
 ## Tools Tab
 Manage the tools that agents can invoke. Add new tools or edit existing ones. 


### PR DESCRIPTION
## Summary
- show all agents in a table with edit buttons
- add editor view with Back and Delete buttons
- refresh table when agents are added or removed
- update user guide for new agent workflow

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbbff348c832684c2f3721cd82b07