### PR TITLE
Fix send icon and placeholder cropping

### DIFF
--- a/dark_mode.qss
+++ b/dark_mode.qss
@@ -119,6 +119,7 @@ QMainWindow {
     border-radius: 5px;
     padding: 8px;
     color: #ffffff;
+    min-height: 50px; /* Prevent placeholder clipping */
 }
 
 #shortcutLabel {

--- a/light_mode.qss
+++ b/light_mode.qss
@@ -125,7 +125,7 @@ QMainWindow {
     border-radius: 5px;
     padding: 8px;
     color: #333333;
-    min-height: 40px; /* Ensuring enough space for placeholder text */
+    min-height: 50px; /* Ensuring enough space for placeholder text */
 }
 
 #shortcutLabel {

--- a/tab_chat.py
+++ b/tab_chat.py
@@ -130,7 +130,8 @@ class ChatTab(QWidget):
         self.user_input = QTextEdit()
         self.user_input.setObjectName("userInput")
         self.user_input.setPlaceholderText("Type your message here...")
-        self.user_input.setMinimumHeight(40)  # Set minimum height
+        # Increase minimum height so placeholder text isn't cropped
+        self.user_input.setMinimumHeight(50)
         self.user_input.setMaximumHeight(100)
         self.user_input.installEventFilter(self)
         input_layout.addWidget(self.user_input)
@@ -152,7 +153,9 @@ class ChatTab(QWidget):
         # Create send button with modern styling
         self.send_button = QPushButton("Send")
         self.send_button.setObjectName("sendButton")
-        self.send_button.setIcon(self.style().standardIcon(getattr(QStyle, 'SP_ArrowRight')))
+        icon = self.style().standardIcon(QStyle.SP_ArrowRight)
+        self.send_button.setIcon(icon)
+        self.send_button.setIconSize(QtCore.QSize(16, 16))
         self.send_button.setToolTip("Send the message (Enter)")
         btn_layout.addWidget(self.send_button)
         


### PR DESCRIPTION
## Summary
- adjust chat input height so placeholder text isn't cut off
- ensure send button icon is visible
- set minimum height for user input in dark theme

## Testing
- `pip install -r requirements-dev.txt`
- `pip install requests sympy PyQt5`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbd90db94832696ec9255ea1e0def