### PR TITLE
Set default due time to +1 minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Includes a built-in **File Summarizer** tool for generating quick summaries of text files.
 
 *   **Task Scheduling:**
-    *   Agents can schedule tasks to be executed at a specific time.
+    *   Agents can schedule tasks to be executed at a specific time. New tasks default to one minute from the current time.
     *   Tasks are stored in `tasks.json`.
     *   Tasks appear on a drag-and-drop calendar for easy rescheduling and completion.
     *   Tasks can optionally repeat at a set interval.

--- a/dialogs.py
+++ b/dialogs.py
@@ -131,11 +131,11 @@ class TaskDialog(QDialog):
                 print(f"Error parsing due time: {due_time}")
                 # Handle invalid date time format
                 QMessageBox.warning(
-                    self, "Error", "Invalid due time format. Using current time."
+                    self, "Error", "Invalid due time format. Using current time + 1 minute."
                 )
-                self.due_time_edit.setDateTime(QDateTime.currentDateTime())
-        else: 
-            self.due_time_edit.setDateTime(QDateTime.currentDateTime())
+                self.due_time_edit.setDateTime(QDateTime.currentDateTime().addSecs(60))
+        else:
+            self.due_time_edit.setDateTime(QDateTime.currentDateTime().addSecs(60))
 
         self.due_time_edit.setToolTip("Select the due time for the task.")
         self.due_time_edit.setCalendarPopup(True)  # Enable calendar popup

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -47,7 +47,7 @@ Agents with tool use enabled can invoke these tools by returning a JSON block in
 ## Tasks Tab
 The Tasks tab manages scheduled prompts. Tasks are displayed in a list and on a calendar. The current day is highlighted and dates with tasks show a red dot in the corner. You can drag tasks to different dates to reschedule them. Double-clicking a task toggles its status between **pending** and **completed**. Buttons allow you to:
 
-- **Add Task** – create a new task specifying agent, prompt and due time.
+- **Add Task** – create a new task specifying agent, prompt and due time. The due time defaults to one minute from now.
 - **Edit** – change an existing task.
 - **Delete** – remove a task after confirmation.
 - **Toggle Status** – mark the selected task as completed or pending.


### PR DESCRIPTION
## Summary
- use current time + 1 minute as the default due time when creating tasks
- document the new default in the README and user guide

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc161e90483268febb5bca24d7501