### PR TITLE
Add dropdown for model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 ## Key Features
 
 *   **Multiple AI Agents:** Create and manage multiple AI agents, each with its own:
-    *   Underlying language model (e.g., `llama3.2-vision`, `llava`).
+    *   Underlying language model selected from a dropdown of available Ollama models (e.g., `llama3.2-vision`, `llava`).
     *   Custom system prompt to define its behavior and personality.
     *   Temperature and max tokens settings to control response randomness and length.
     *   Assigned role:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,7 +8,7 @@ The Chat tab is the primary interface for interacting with your agents. Use the 
 ## Agents Tab
 The Agents tab lets you create and configure AI agents. Every agent stores the following settings:
 
-- **Model** – name of the language model (for example `llava` or `llama3.2-vision`).
+- **Model** – select the language model from a dropdown of installed Ollama models (for example `llava` or `llama3.2-vision`).
 - **Temperature** – controls randomness of the output.
 - **Max Tokens** – maximum length of a single response.
 - **Custom System Prompt** – additional instructions sent before every conversation.


### PR DESCRIPTION
## Summary
- make agents model field a dropdown
- fetch model names from a running Ollama instance
- document model dropdown in README and user guide

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc2a25620832685b98a2b9ad2f5eb