### PR TITLE
Fix QSpinBox import for Task dialog

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1,8 +1,21 @@
 # dialogs.py
 
 from PyQt5.QtWidgets import (
-    QDialog, QVBoxLayout, QLineEdit, QTextEdit, QLabel, QPushButton, QHBoxLayout,
-    QComboBox, QStyle, QColorDialog, QCheckBox, QDateTimeEdit, QDialogButtonBox, QMessageBox
+    QDialog,
+    QVBoxLayout,
+    QLineEdit,
+    QTextEdit,
+    QLabel,
+    QPushButton,
+    QHBoxLayout,
+    QComboBox,
+    QStyle,
+    QColorDialog,
+    QCheckBox,
+    QDateTimeEdit,
+    QDialogButtonBox,
+    QMessageBox,
+    QSpinBox,
 )
 from PyQt5.QtCore import Qt, QDateTime
 


### PR DESCRIPTION
## Summary
- import `QSpinBox` in `dialogs.py` so adding tasks works again

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc5a4ff3c8326b4ead31c02cc7896