### PR TITLE
Add Ollama update controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
         from websites.
     *   Includes a built-in **File Summarizer** tool for generating quick summaries of text files.
     *   Tools can be updated using the **Edit Tool** button in the Tools tab.
+    *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models.
 
 *   **Task Scheduling:**
     *   Agents can schedule tasks to be executed at a specific time. New tasks default to one minute from the current time.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -68,3 +68,10 @@ These metrics are updated whenever agents use tools or complete tasks.
 ## Documentation Tab
 The Documentation tab simply renders this `user_guide.md` file. It allows in-app viewing of the full user guide without leaving Cerebro.
 
+## Settings Dialog
+The Settings dialog contains global preferences for the application.
+
+- Toggle dark mode and set your user name.
+- Use **Update Ollama** to download the latest Ollama release.
+- Select a model in the drop-down and click **Update Model** to pull its newest version.
+


### PR DESCRIPTION
## Summary
- add Update Ollama and Update Model buttons to the Settings dialog
- document the new settings in the README and user guide

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc4b97bc48326a4787f177e277e1c