### PR TITLE
Add save button for agent editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
         *   **Coordinator:** Manages other agents and delegates tasks.
         *   **Assistant:** Responds directly to user queries.
         *   **Specialist:** Responds only to requests from a Coordinator.
-    *   Configurable color in the chat UI.
+     *   Configurable color in the chat UI.
+     *   Rename agents on the edit page and press **Save** to apply changes.
 *   **Agent Roles:**
     *   **Coordinator:**  The Coordinator agent acts as a central hub. It receives user input, intelligently selects the most appropriate Specialist or Assistant agent to handle the request (based on agent descriptions and the nature of the query), and then displays the chosen agent's response. The Coordinator can also add context or modify the user's prompt before passing it on. When a Coordinator is done, it will pass the conversation on to another agent by specifying the phrase "Next Response By: [Agent Name]".
     *   **Assistant:** Assistant agents behave like traditional chatbots, responding directly to user input in the chat window.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -20,10 +20,11 @@ The Agents tab lets you create and configure AI agents. Every agent stores the f
 - **Tool Use** – allow the agent to call tools.
 - **Enabled Tools** – choose which tools are available when tool use is on.
 
-Changes are saved automatically when you modify a field. The Agents tab opens to
-a table listing all agents with an **Edit** button next to each one. Use
-**Add New Agent** to create a new entry. When editing an agent you can return to
-the list with **Back** or remove it with **Delete Agent**.
+After adjusting any fields press **Save** to store your changes. You can also
+rename an agent using the **Agent Name** field. The Agents tab opens to a table
+listing all agents with an **Edit** button next to each one. Use **Add New
+Agent** to create a new entry. When editing an agent you can return to the list
+with **Back** or remove it with **Delete Agent**.
 
 ## Tools Tab
 Manage the tools that agents can invoke. Add new tools or edit existing ones. 


### PR DESCRIPTION
## Summary
- allow renaming agents with an `Agent Name` field
- add a Save button to the agent editor
- store changes only when Save is clicked
- document new workflow in README and user guide

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q PyQt5 requests`
- `pip install -q sympy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc540e0188326a62fc5ff79b650b8