### PR TITLE
Fix chat history persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Tasks can optionally repeat at a set interval.
         Today's date is highlighted and any date with tasks shows a small red dot.
     *   The included **Windows Notifier** tool can display Windows 11 notifications when a scheduled task runs.
-*   **Chat History Persistence:**
-    *   Conversations are saved to `chat_history.json` for each session.
-    *   History can be exported or cleared from the chat menu.
+*   **Chat History Management:**
+    *   Each session begins with a blank conversation.
+    *   History can be exported or cleared from the chat menu if desired.
 *   **Conversation Summaries:**
     *   Older messages are automatically condensed when a chat grows large to
         keep prompts short.

--- a/app.py
+++ b/app.py
@@ -52,8 +52,8 @@ class AIChatApp(QMainWindow):
         self.setGeometry(100, 100, 1000, 700)  # Larger default window
 
         # Variables
-        self.chat_history = load_history(self.debug_enabled)
-        self.chat_history = summarize_history(self.chat_history)
+        clear_history(self.debug_enabled)
+        self.chat_history = []
         self.current_responses = {}
         self.agents_data = {}
         self.include_image = False
@@ -516,6 +516,7 @@ class AIChatApp(QMainWindow):
         if self.debug_enabled:
             print("[Debug] Clearing chat.")
         self.chat_tab.chat_display.clear()
+        clear_history(self.debug_enabled)
         self.chat_history = []
         self.show_notification("Chat cleared")
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -3,7 +3,7 @@
 This guide provides a detailed overview of Cerebro's features. Each section corresponds to one of the application's tabs.
 
 ## Chat Tab
-The Chat tab is the primary interface for interacting with your agents. Use the text box at the bottom to send a prompt. Messages appear in a scrollable window above the input field. The chat history can be copied, exported or cleared using the menu in the top right corner. While an agent is generating a response a "typing" indicator is displayed.
+The Chat tab is the primary interface for interacting with your agents. Use the text box at the bottom to send a prompt. Messages appear in a scrollable window above the input field. The chat history can be copied, exported or cleared using the menu in the top right corner. Each time the application starts you begin with a fresh conversation. While an agent is generating a response a "typing" indicator is displayed.
 
 ## Agents Tab
 The Agents tab lets you create and configure AI agents. Every agent stores the following settings:


### PR DESCRIPTION
## Summary
- ensure prior chat transcripts are removed at startup
- clear stored history when clearing the chat
- document that each session starts blank

## Testing
- `pip install -r requirements-dev.txt`
- `pip install PyQt5 requests sympy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc65e30888326ab550feb1ed712ed