### PR TITLE
Improve Ollama update handling

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -272,8 +272,16 @@ class SettingsDialog(QDialog):
             result = subprocess.run(
                 ["ollama", "update"], capture_output=True, text=True, timeout=300
             )
-            output = result.stdout.strip() or "Update complete."
-            QMessageBox.information(self, "Ollama Update", output)
+            if result.returncode == 0:
+                output = (
+                    result.stdout.strip()
+                    or result.stderr.strip()
+                    or "Update complete."
+                )
+                QMessageBox.information(self, "Ollama Update", output)
+            else:
+                error_msg = result.stderr.strip() or "Ollama update failed."
+                QMessageBox.warning(self, "Ollama Update", error_msg)
         except FileNotFoundError:
             QMessageBox.warning(self, "Error", "Ollama executable not found.")
         except Exception as e:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -74,5 +74,6 @@ The Settings dialog contains global preferences for the application.
 
 - Toggle dark mode and set your user name.
 - Use **Update Ollama** to download the latest Ollama release.
+- If the update fails, an error message will be displayed.
 - Select a model in the drop-down and click **Update Model** to pull its newest version.
 


### PR DESCRIPTION
## Summary
- handle errors from `ollama update` and show them to the user
- document that the settings dialog reports update failures

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc734b81883268570eabab1ff3ff8