### PR TITLE
Enable editing of plugin tools

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -40,7 +40,8 @@ Tools extend Cerebro with custom Python scripts. The Tools tab shows all tools l
 3. **Delete** – permanently remove a tool and its script file.
 4. **Run** – test a tool by providing JSON arguments.
 
-Plugin tools are listed alongside your own but cannot be edited or deleted.
+Plugin tools are loaded automatically from the `tool_plugins` directory or entry points.
+They behave like regular tools and can be edited or removed from the UI.
 
 Agents with tool use enabled can invoke these tools by returning a JSON block in the format described in `generate_tool_instructions_message()`.
 

--- a/tab_tools.py
+++ b/tab_tools.py
@@ -80,15 +80,9 @@ class ToolsTab(QWidget):
             self.run_button.setEnabled(False)
             return
 
-        item = selected_items[0]
-        is_plugin = item.data(Qt.UserRole + 1)
         self.run_button.setEnabled(True)
-        if is_plugin:
-            self.edit_tool_button.setEnabled(False)
-            self.delete_button.setEnabled(False)
-        else:
-            self.edit_tool_button.setEnabled(True)
-            self.delete_button.setEnabled(True)
+        self.edit_tool_button.setEnabled(True)
+        self.delete_button.setEnabled(True)
 
     def refresh_tools_list(self):
         self.tools_list.clear()


### PR DESCRIPTION
## Summary
- allow plugin tools to be modified like regular tools
- refresh doc statement about plugin tool editing

## Testing
- `pip install -q PyQt5 requests sympy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc7de1a08832684b99b55e1dc1019