### PR TITLE
Fix undefined var when sending messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -446,8 +446,13 @@ class AIChatApp(QMainWindow):
         user_message_html = f'<span style="color:{self.user_color};">[{timestamp}] {self.user_name}:</span> {user_text}'
         self.chat_tab.append_message_html(user_message_html)
 
-        # Persist the user message once
-        append_message(self.chat_history, "user", user_text, debug_enabled=self.debug_enabled)
+        # Persist the user message once and keep the entry for history building
+        user_message = append_message(
+            self.chat_history,
+            "user",
+            user_text,
+            debug_enabled=self.debug_enabled,
+        )
 
         # If a Coordinator agent is enabled, send the message to the Coordinator agents only.
         enabled_coordinator_agents = [


### PR DESCRIPTION
## Summary
- fix `NameError` crash when sending a message after clearing history

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcda3c4208326972ef8e25dd51838