### PR TITLE
Improve tool instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ This file defines available tools.
 
 name: The name of the tool.
 description: A brief description of the tool.
+args: (optional) List of argument names the tool accepts.
 script: The content of the Python script that implements the tool. The script must define a function called run_tool(args) that takes a dictionary of arguments and returns a string.
 script_path: (optional) Path to a Python file containing the tool implementation. If script_path is missing but script is provided, the application will run the script from a temporary file.
 Tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point
@@ -193,6 +194,7 @@ Example:
   {
     "name": "schedule-task",
     "description": "Schedule a future prompt to run at the specified time.",
+    "args": ["agent_name", "prompt", "due_time"],
     "script": "def run_tool(args):\\n  import os\\n  import sys\\n  from tasks import load_tasks, save_tasks, add_task\\n  # The agent will pass arguments like:\\n  # {\\n  # \\"agent_name\\": \\"Agent X\\",\\n  # \\"prompt\\": \\"some scheduled prompt\\",\\n  # \\"due_time\\": \\"2024-12-31T23:59:59\\"\\n  # }\\n  agent_name = args.get(\\"agent_name\\", \\"Default Agent\\")\\n  prompt = args.get(\\"prompt\\", \\"No prompt provided\\")\\n  due_time = args.get(\\"due_time\\", \\"\\")\\n  tasks = load_tasks(False) #\\n  # load current tasks\\n  if not due_time:\\n   return \\"[schedule-task Error] No due_time provided.\\"\\n  # Add the task, marking creator as 'agent' or 'user' as you prefer.\\n  add_task(tasks, agent_name, prompt, due_time, creator=\\"agent\\", debug_enabled=False)\\n  return f\\"Task scheduled: Agent '{agent_name}' at '{due_time}' with prompt '{prompt}'.\\""
   }
 ]

--- a/message_broker.py
+++ b/message_broker.py
@@ -410,7 +410,11 @@ class MessageBroker:
             tool_list_str = ""
             for t in self.app.tools:
                 if t['name'] in enabled_tools:
-                    tool_list_str += f"- {t['name']}: {t['description']}\n"
+                    args = ", ".join(t.get("args", []))
+                    if args:
+                        tool_list_str += f"- {t['name']}({args}): {t['description']}\n"
+                    else:
+                        tool_list_str += f"- {t['name']}: {t['description']}\n"
 
             instructions = (
                 "You are a knowledgeable assistant. You can answer most questions directly.\n"

--- a/tool_plugins/file_summarizer.py
+++ b/tool_plugins/file_summarizer.py
@@ -1,6 +1,7 @@
 TOOL_METADATA = {
     "name": "file-summarizer",
-    "description": "Summarize the contents of a text file or provided text"
+    "description": "Summarize the contents of a text file or provided text",
+    "args": ["file_path", "text"]
 }
 
 

--- a/tool_plugins/math_solver.py
+++ b/tool_plugins/math_solver.py
@@ -1,6 +1,7 @@
 TOOL_METADATA = {
     "name": "math-solver",
-    "description": "Solve mathematical expressions or equations using SymPy and return a JSON-formatted result."
+    "description": "Solve mathematical expressions or equations using SymPy and return a JSON-formatted result.",
+    "args": ["expression", "equation"]
 }
 
 import json

--- a/tool_plugins/web_scraper.py
+++ b/tool_plugins/web_scraper.py
@@ -7,7 +7,8 @@ import requests
 
 TOOL_METADATA = {
     "name": "web-scraper",
-    "description": "Fetch and return text content from a URL."
+    "description": "Fetch and return text content from a URL.",
+    "args": ["url", "timeout"]
 }
 
 

--- a/tool_plugins/windows_notifier.py
+++ b/tool_plugins/windows_notifier.py
@@ -1,6 +1,7 @@
 TOOL_METADATA = {
     "name": "windows-notifier",
-    "description": "Send a Windows 11 notification using win10toast."
+    "description": "Send a Windows 11 notification using win10toast.",
+    "args": ["title", "message"]
 }
 
 

--- a/tools.json
+++ b/tools.json
@@ -2,6 +2,7 @@
   {
     "name": "schedule-task",
     "description": "Schedule a future prompt to run at the specified time. Useful for reminding the user of something in the future or continuing work at a later time.",
+    "args": ["agent_name", "prompt", "due_time"],
     "script": "def run_tool(args): import os import sys from tasks import load_tasks, save_tasks, add_task # The agent will pass arguments like: # { # \"agent_name\": \"Agent X\", # \"prompt\": \"some scheduled prompt\", # \"due_time\": \"2024-12-31T23:59:59\" # } agent_name = args.get(\"agent_name\", \"Default Agent\") prompt = args.get(\"prompt\", \"No prompt provided\") due_time = args.get(\"due_time\", \"\") tasks = load_tasks(False) # # load current tasks if not due_time: return \"[schedule-task Error] No due_time provided.\" # Add the task, marking creator as 'agent' or 'user' as you prefer. add_task(tasks, agent_name, prompt, due_time, creator=\"agent\", debug_enabled=False) return f\"Task scheduled: Agent '{agent_name}' at '{due_time}' with prompt '{prompt}'.\""
   }
 ]

--- a/tools.py
+++ b/tools.py
@@ -38,6 +38,7 @@ def discover_plugin_tools(debug_enabled=False):
                     "plugin_module": module,
                     "script_path": path,
                     "script": script_text,
+                    "args": meta.get("args", [])
                 })
                 if debug_enabled:
                     print(f"[Debug] Loaded plugin tool '{meta['name']}' from {path}")
@@ -67,6 +68,7 @@ def discover_plugin_tools(debug_enabled=False):
                     "plugin_module": module,
                     "script_path": path,
                     "script": script_text,
+                    "args": meta.get("args", [])
                 })
                 if debug_enabled:
                     print(f"[Debug] Loaded plugin tool '{meta['name']}' from entry point")


### PR DESCRIPTION
## Summary
- document `args` field for tools
- show tool arguments in instructions
- support optional arguments in tool metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd0497a848326a10564387f53a7dd