### PR TITLE
Add test for tools.run_tool

### DIFF
--- a/tests/test_tools_run.py
+++ b/tests/test_tools_run.py
@@ -1,0 +1,9 @@
+import tools
+from tool_plugins import echo_plugin
+
+
+def test_run_tool_echo():
+    plugins = tools.load_tools()
+    result_direct = echo_plugin.run_tool({"msg": "hello"})
+    result_via_tools = tools.run_tool(plugins, "echo-plugin", {"msg": "hello"})
+    assert result_direct == result_via_tools

--- a/tools.py
+++ b/tools.py
@@ -113,6 +113,18 @@ def run_tool(tools, tool_name, args, debug_enabled=False):
     plugin_module = tool.get("plugin_module")
     cleanup_tmp = False
 
+    if plugin_module and hasattr(plugin_module, "run_tool"):
+        try:
+            result = plugin_module.run_tool(args)
+            if debug_enabled:
+                print(f"[Debug] Tool '{tool_name}' output: {result}")
+            return result
+        except Exception as e:
+            error_msg = f"[Tool Error] Exception running tool '{tool_name}': {e}"
+            if debug_enabled:
+                print(f"[Debug] {error_msg}")
+            return error_msg
+
     if not script_path and plugin_module:
         script_path = getattr(plugin_module, "__file__", "")
         if script_path and os.path.exists(script_path):


### PR DESCRIPTION
## Summary
- add test for running plugin tools via `tools.run_tool`
- call plugin modules directly from `tools.run_tool` when available

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd22c4cdc8326bb18ce7da0f484ee