### PR TITLE
Add sample agents for each role

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -151,5 +151,50 @@
         "include_image": false,
         "desktop_history_enabled": false,
         "screenshot_interval": 5
+    },
+    "Example Assistant": {
+        "model": "gemma3:12b",
+        "temperature": 0.7,
+        "max_tokens": 512,
+        "system_prompt": "You are a helpful assistant.",
+        "enabled": false,
+        "description": "Demonstrates a basic assistant.",
+        "role": "Assistant",
+        "tool_use": false,
+        "color": "#123456",
+        "managed_agents": [],
+        "tools_enabled": [],
+        "desktop_history_enabled": false,
+        "screenshot_interval": 5
+    },
+    "Example Coordinator": {
+        "model": "gemma3:12b",
+        "temperature": 0.7,
+        "max_tokens": 512,
+        "system_prompt": "Coordinate tasks and delegate. End with 'Next Response By: [Agent Name]'.",
+        "enabled": false,
+        "description": "Demonstrates delegating tasks to other agents.",
+        "role": "Coordinator",
+        "tool_use": false,
+        "color": "#654321",
+        "managed_agents": ["Example Specialist", "Example Assistant"],
+        "tools_enabled": [],
+        "desktop_history_enabled": false,
+        "screenshot_interval": 5
+    },
+    "Example Specialist": {
+        "model": "gemma3:12b",
+        "temperature": 0.7,
+        "max_tokens": 512,
+        "system_prompt": "Answer only when instructed by a Coordinator.",
+        "enabled": false,
+        "description": "Demonstrates a specialist agent.",
+        "role": "Specialist",
+        "tool_use": false,
+        "color": "#abcdef",
+        "managed_agents": [],
+        "tools_enabled": [],
+        "desktop_history_enabled": false,
+        "screenshot_interval": 5
     }
 }


### PR DESCRIPTION
## Summary
- add `Example Assistant`, `Example Coordinator`, and `Example Specialist`
- demonstrate their configuration using the gemma3:12b model

## Testing
- `pip install -r requirements-dev.txt`
- `pip install PyQt5 requests win10toast sympy` *(fails: Getting requirements to build wheel did not run successfully)*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_683fd32d9be483269c32ebe2b325a06b