### PR TITLE
Fix schedule-task tool script

### DIFF
--- a/tests/test_schedule_tool.py
+++ b/tests/test_schedule_tool.py
@@ -1,0 +1,28 @@
+import tools
+import tasks
+
+
+def noop_save(tasks_, debug_enabled=False):
+    pass
+
+
+def test_schedule_tool(monkeypatch):
+    tools_list = tools.load_tools()
+    monkeypatch.setattr(tasks, "save_tasks", noop_save)
+    captured = {}
+
+    def fake_add_task(task_list, agent, prompt, due_time, creator="user", repeat_interval=0, debug_enabled=False):
+        captured["agent"] = agent
+        captured["prompt"] = prompt
+        captured["due_time"] = due_time
+        return "id"
+
+    monkeypatch.setattr(tasks, "add_task", fake_add_task)
+    monkeypatch.setattr(tasks, "load_tasks", lambda debug=False: [])
+
+    args = {"agent_name": "tester", "prompt": "hello", "due_time": "2099-01-01T00:00:00"}
+    result = tools.run_tool(tools_list, "schedule-task", args)
+
+    assert "Task scheduled" in result
+    assert captured == {"agent": "tester", "prompt": "hello", "due_time": "2099-01-01T00:00:00"}
+

--- a/tools.json
+++ b/tools.json
@@ -3,6 +3,6 @@
     "name": "schedule-task",
     "description": "Schedule a future prompt to run at the specified time. Useful for reminding the user of something in the future or continuing work at a later time.",
     "args": ["agent_name", "prompt", "due_time"],
-    "script": "def run_tool(args): import os import sys from tasks import load_tasks, save_tasks, add_task # The agent will pass arguments like: # { # \"agent_name\": \"Agent X\", # \"prompt\": \"some scheduled prompt\", # \"due_time\": \"2024-12-31T23:59:59\" # } agent_name = args.get(\"agent_name\", \"Default Agent\") prompt = args.get(\"prompt\", \"No prompt provided\") due_time = args.get(\"due_time\", \"\") tasks = load_tasks(False) # # load current tasks if not due_time: return \"[schedule-task Error] No due_time provided.\" # Add the task, marking creator as 'agent' or 'user' as you prefer. add_task(tasks, agent_name, prompt, due_time, creator=\"agent\", debug_enabled=False) return f\"Task scheduled: Agent '{agent_name}' at '{due_time}' with prompt '{prompt}'.\""
+    "script": "def run_tool(args):\n    from tasks import load_tasks, add_task\n    agent_name = args.get('agent_name', 'Default Agent')\n    prompt = args.get('prompt', 'No prompt provided')\n    due_time = args.get('due_time', '')\n    tasks = load_tasks(False)\n    if not due_time:\n        return '[schedule-task Error] No due_time provided.'\n    add_task(tasks, agent_name, prompt, due_time, creator='agent', debug_enabled=False)\n    return f'Task scheduled: Agent {agent_name!r} at {due_time!r} with prompt {prompt!r}.'"
   }
 ]


### PR DESCRIPTION
## Summary
- fix schedule-task script so it executes correctly
- add regression test for schedule-task

## Testing
- `pip install -r requirements-dev.txt`
- `pip install PyQt5 requests sympy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd53c737883269dee80ba713b4809