### PR TITLE
Add Windows installer build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
         *   **Linux/macOS:** `DEBUG_MODE=1 python main.py`
         *   **Windows:** `set DEBUG_MODE=1 & python main.py`
 
+## Windows Installer
+
+Use PyInstaller to create a stand-alone Windows build. First install PyInstaller and then run `build_windows_installer.bat` from a command prompt. The executable will be created in the `dist` directory.
+
+
 ## Configuration
 
 ### `agents.json`

--- a/build_windows_installer.bat
+++ b/build_windows_installer.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Build stand-alone Cerebro installer using PyInstaller
+pyinstaller --clean --noconfirm cerebro.spec

--- a/cerebro.spec
+++ b/cerebro.spec
@@ -1,0 +1,35 @@
+# -*- mode: python ; coding: utf-8 -*-
+block_cipher = None
+
+a = Analysis(['main.py'],
+             pathex=['.'],
+             binaries=[],
+             datas=[('dark_mode.qss', '.'), ('light_mode.qss', '.')],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          [],
+          exclude_binaries=True,
+          name='Cerebro',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=False)
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=True,
+               upx_exclude=[],
+               name='Cerebro')

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -29,6 +29,8 @@ Cerebro and describes every tab and feature so you can quickly become productive
    ```
    Set the environment variable `DEBUG_MODE=1` to enable verbose logging.
 
+To create a Windows installer, install PyInstaller and run `build_windows_installer.bat`. The resulting executable will appear in the `dist` directory.
+
 ## Application Overview
 
 The main window is divided into several tabs. Use the numbered shortcuts `Ctrl+1` – `Ctrl+6` to switch


### PR DESCRIPTION
## Summary
- allow bundling on Windows with new `cerebro.spec`
- add batch helper `build_windows_installer.bat`
- document PyInstaller usage in README and user guide

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bad63ba883268d59030c36399a47