### PR TITLE
Add local LLM deployment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,21 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
     pip install -r requirements.txt
     ```
 
+5.  *(Optional)* **Install the Ollama runtime and a model:**
+
+    ```bash
+    python local_llm_helper.py install
+    python local_llm_helper.py download llama3
+    ```
+
 ## Usage
 
 1.  **Start the Ollama server:**
-    Make sure your Ollama server is running in the background. Refer to the Ollama documentation for instructions. You can use the command `ollama serve` to start it.
+    Make sure your Ollama server is running in the background. You can launch it manually with `ollama serve` or run:
+
+    ```bash
+    python local_llm_helper.py serve
+    ```
 
 2.  **Run the Cerebro application:**
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -23,7 +23,12 @@ Cerebro and describes every tab and feature so you can quickly become productive
    ```bash
    pip install -r requirements.txt
    ```
-4. Start the Ollama server separately and then run the application:
+4. (Optional) Use the helper script to install Ollama and download a model:
+   ```bash
+   python local_llm_helper.py install
+   python local_llm_helper.py download llama3
+   ```
+5. Start the Ollama server separately and then run the application:
    ```bash
    python main.py
    ```

--- a/local_llm_helper.py
+++ b/local_llm_helper.py
@@ -1,0 +1,65 @@
+import argparse
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def check_ollama_installed() -> bool:
+    """Return True if the Ollama executable is available."""
+    return shutil.which("ollama") is not None
+
+
+def install_ollama() -> None:
+    """Download and run the Ollama installer on Windows or print instructions."""
+    if check_ollama_installed():
+        print("Ollama is already installed.")
+        return
+
+    if platform.system() == "Windows":
+        url = "https://ollama.com/download/OllamaSetup.exe"
+        exe = Path("OllamaSetup.exe")
+        if not exe.exists():
+            print("Downloading Ollama installer...")
+            subprocess.run([
+                "powershell",
+                "-Command",
+                f"Invoke-WebRequest '{url}' -OutFile '{exe}'"
+            ], check=True)
+        print("Running installer...")
+        subprocess.run([str(exe)], check=True)
+    else:
+        print("Please install Ollama manually from https://ollama.com for your platform.")
+
+
+def download_model(model: str) -> None:
+    """Download the specified model using 'ollama pull'."""
+    if not model:
+        raise ValueError("Model name cannot be empty")
+    subprocess.run(["ollama", "pull", model], check=True)
+
+
+def start_server() -> None:
+    """Start the Ollama server."""
+    subprocess.run(["ollama", "serve"], check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Local LLM deployment helper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("install", help="Install the Ollama runtime")
+    dl = sub.add_parser("download", help="Download a model")
+    dl.add_argument("model", help="Model name to download")
+    sub.add_parser("serve", help="Start the Ollama server")
+    args = parser.parse_args()
+
+    if args.cmd == "install":
+        install_ollama()
+    elif args.cmd == "download":
+        download_model(args.model)
+    elif args.cmd == "serve":
+        start_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_local_llm_helper.py
+++ b/tests/test_local_llm_helper.py
@@ -1,0 +1,8 @@
+import local_llm_helper as llh
+
+
+def test_check_ollama_installed(monkeypatch):
+    monkeypatch.setattr(llh.shutil, "which", lambda cmd: "/usr/bin/ollama")
+    assert llh.check_ollama_installed() is True
+    monkeypatch.setattr(llh.shutil, "which", lambda cmd: None)
+    assert llh.check_ollama_installed() is False


### PR DESCRIPTION
## Summary
- create `local_llm_helper.py` for installing Ollama, downloading models and running the server
- document helper script usage in README and user guide
- add unit test for helper

## Testing
- `PYTHONPATH=. pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6840be0281f08326ac5d48944870b756