### PR TITLE
Add AR overlay plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ Another bundled plugin named `web-scraper` fetches and sanitizes text from a URL
 The repository also provides a `windows-notifier` plugin that relies on the
 `win10toast` package to display a Windows 11 notification. Pair it with the
 `schedule-task` tool to create reminders or daily summaries.
-The `desktop-automation` plugin can launch programs or move files after a model
-analyzes your screen captures.
+The new `ar-overlay` plugin pops up a small HUD-style window with a short
+message, and the `desktop-automation` plugin can launch programs or move files
+after a model analyzes your screen captures.
 Scheduled tasks are also written to the OS task scheduler using the helper
 script `run_task.py` so they execute even when Cerebro is not running.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -94,6 +94,7 @@ Bundled plugins include:
 - **web-scraper** – download and sanitize text from a URL.
 - **math-solver** – evaluate mathematical expressions.
 - **windows-notifier** – display a Windows 11 notification using `win10toast`.
+- **ar-overlay** – show a small on-screen HUD message for quick reminders.
 - **desktop-automation** – launch programs or move files through OS commands.
 
 Agents call tools by returning a JSON block in the format produced by

--- a/tests/test_ar_overlay.py
+++ b/tests/test_ar_overlay.py
@@ -1,0 +1,6 @@
+from tool_plugins import ar_overlay
+
+
+def test_run_overlay_returns_string():
+    result = ar_overlay.run_tool({"message": "test"})
+    assert isinstance(result, str)

--- a/tool_plugins/ar_overlay.py
+++ b/tool_plugins/ar_overlay.py
@@ -1,0 +1,42 @@
+TOOL_METADATA = {
+    "name": "ar-overlay",
+    "description": "Display a floating desktop overlay message.",
+    "args": ["message"],
+}
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def run_tool(args):
+    """Show an HUD-style overlay message using Tkinter."""
+    message = args.get("message", "Cerebro")
+    try:
+        script = textwrap.dedent(
+            """
+            import sys
+            import tkinter as tk
+
+            msg = sys.argv[1] if len(sys.argv) > 1 else "Cerebro"
+            root = tk.Tk()
+            root.overrideredirect(True)
+            root.attributes('-topmost', True)
+            root.attributes('-alpha', 0.85)
+            root.configure(bg='black')
+            label = tk.Label(root, text=msg, fg='white', bg='black', font=('Segoe UI', 12, 'bold'))
+            label.pack(ipadx=10, ipady=5)
+            root.update_idletasks()
+            x = root.winfo_screenwidth() - root.winfo_reqwidth() - 20
+            root.geometry(f'+{x}+40')
+            root.after(5000, root.destroy)
+            root.mainloop()
+            """
+        )
+        if sys.platform != 'win32' and not os.environ.get('DISPLAY'):
+            return "[ar-overlay Warning] Display not available."
+        subprocess.Popen([sys.executable, '-c', script, message])
+        return "Overlay shown"
+    except Exception as e:
+        return f"[ar-overlay Error] {e}"


### PR DESCRIPTION
## Summary
- introduce `ar-overlay` tool plugin for HUD-style reminders
- document AR overlay plugin in README and user guide
- add basic test verifying the plugin runs

## Testing
- `pip install -q PyQt5 requests sympy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684205006c608326ae9073b92da3c664