### PR TITLE
Improve test coverage and update development guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,18 @@ Follow these guidelines when modifying the project.
 - Follow basic PEP8 conventions where practical.
 - Document public functions with docstrings.
 - Keep line length under 120 characters.
+- Aim for compatibility with Windows 11 whenever possible.
 
 ## Testing
-- Install test dependencies with `pip install -r requirements-dev.txt`.
-- Run the test suite before committing using:
+- Install dependencies with `pip install -r requirements.txt` and
+  `pip install -r requirements-dev.txt`.
+- Run the linter and test suite before committing using:
   ```bash
+  flake8 .
   PYTHONPATH=. pytest -q
   ```
+- Skip linting and tests only when modifying comments or documentation.
+- Ensure new functionality includes corresponding tests.
 - Only commit changes when all tests pass.
 
 ## Commit Messages

--- a/README.md
+++ b/README.md
@@ -234,6 +234,17 @@ This file stores the list of scheduled tasks. Each task entry includes an ``id``
 ``agent_name``, ``prompt``, ``due_time`` and ``status`` field. The status field defaults to ``pending``.
 You typically won't edit this file directly.
 
+## Testing
+Install the dependencies and run the linter and test suite before submitting
+changes:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+flake8 .
+PYTHONPATH=. pytest -q
+```
+
 ## Contributing
 Contributions are welcome! Please feel free to submit pull requests or open issues.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+flake8

--- a/tests/test_message_broker.py
+++ b/tests/test_message_broker.py
@@ -1,0 +1,34 @@
+import message_broker
+
+class DummyApp:
+    def __init__(self):
+        self.debug_enabled = False
+        self.agents_data = {
+            'agent1': {
+                'system_prompt': 'hi',
+                'role': 'Coordinator',
+                'tool_use': True,
+                'managed_agents': [],
+                'tools_enabled': ['echo-plugin']
+            }
+        }
+        self.tools = [{'name': 'echo-plugin', 'description': 'Echo', 'args': []}]
+
+
+def test_build_agent_chat_history(monkeypatch):
+    app = DummyApp()
+    history = [
+        {'role': 'user', 'content': 'Q'},
+        {'role': 'assistant', 'content': 'A', 'agent': 'agent1'}
+    ]
+    monkeypatch.setattr(message_broker, 'load_history', lambda debug=False: history)
+    monkeypatch.setattr(message_broker, 'summarize_history', lambda h: h)
+    monkeypatch.setattr(message_broker, 'generate_tool_instructions_message', lambda app, name: 'tools')
+    broker = message_broker.MessageBroker(app)
+    chat = broker.build_agent_chat_history('agent1')
+    assert chat[0]['role'] == 'system'
+    assert 'tools' in chat[0]['content']
+    # user and assistant messages preserved
+    assert chat[1]['role'] == 'user'
+    assert chat[2]['role'] == 'assistant'
+

--- a/tests/test_run_task.py
+++ b/tests/test_run_task.py
@@ -1,0 +1,27 @@
+import json
+import run_task
+
+class DummyNotifier:
+    def __init__(self):
+        self.args = None
+    def __call__(self, args):
+        self.args = args
+        return "ok"
+
+def test_run_task_main(tmp_path, monkeypatch):
+    tasks = [{
+        "id": "123",
+        "agent_name": "A",
+        "prompt": "Do it",
+        "status": "pending"
+    }]
+    tasks_file = tmp_path / "tasks.json"
+    tasks_file.write_text(json.dumps(tasks))
+    monkeypatch.setattr(run_task, "TASKS_FILE", str(tasks_file))
+    dummy = DummyNotifier()
+    monkeypatch.setattr(run_task, "notify", dummy)
+    run_task.main("123")
+    updated = json.loads(tasks_file.read_text())
+    assert updated[0]["status"] == "completed"
+    assert dummy.args == {"title": "Cerebro Task", "message": "A: Do it"}
+

--- a/tests/test_tool_utils.py
+++ b/tests/test_tool_utils.py
@@ -1,0 +1,32 @@
+import types
+import tool_utils
+
+class DummyApp:
+    def __init__(self):
+        self.agents_data = {
+            'agent1': {
+                'tool_use': True,
+                'tools_enabled': ['echo-plugin']
+            },
+            'agent2': {
+                'tool_use': False,
+                'tools_enabled': []
+            }
+        }
+        self.tools = [
+            {'name': 'echo-plugin', 'description': 'Echo', 'args': ['msg']}
+        ]
+
+
+def test_generate_tool_instructions_enabled():
+    app = DummyApp()
+    instructions = tool_utils.generate_tool_instructions_message(app, 'agent1')
+    assert 'echo-plugin' in instructions
+    assert 'Available tools' in instructions
+
+
+def test_generate_tool_instructions_disabled():
+    app = DummyApp()
+    instructions = tool_utils.generate_tool_instructions_message(app, 'agent2')
+    assert instructions == ''
+


### PR DESCRIPTION
## Summary
- add unit tests for run_task, message_broker and tool_utils
- document running flake8 and pytest in README
- update AGENTS instructions about linting and testing
- include flake8 in development requirements

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420590969c83268143ccd779fab1eb