### PR TITLE
Improve settings dialog performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Includes a built-in **File Summarizer** tool for generating quick summaries of text files.
     *   Provides a **Desktop Automation** plugin for launching programs or moving files via OS commands.
     *   Tools can be updated using the **Edit Tool** button in the Tools tab.
-    *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models.
+    *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models. Model names are cached so the dialog opens quickly.
 
 *   **Task Scheduling:**
     *   Agents can schedule tasks to be executed at a specific time. New tasks default to one minute from the current time.

--- a/app.py
+++ b/app.py
@@ -423,7 +423,7 @@ class AIChatApp(QMainWindow):
             self.user_color = settings_data["user_color"]
             self.debug_enabled = settings_data["debug_enabled"]
             self.apply_updated_styles()
-            self.agents_tab.load_global_preferences()
+            self.agents_tab.update_model_dropdown()
             self.save_settings()
             self.show_notification("Settings updated successfully")
 

--- a/dialogs.py
+++ b/dialogs.py
@@ -236,7 +236,14 @@ class SettingsDialog(QDialog):
         update_layout.addWidget(self.update_ollama_button)
 
         self.model_combo = QComboBox()
-        models = self.parent.agents_tab.fetch_available_models()
+        models = self.parent.agents_tab.global_agent_preferences.get(
+            "available_models", []
+        )
+        if not models:
+            self.parent.agents_tab.load_global_preferences()
+            models = self.parent.agents_tab.global_agent_preferences.get(
+                "available_models", []
+            )
         self.model_combo.addItems(models)
         update_layout.addWidget(self.model_combo)
 
@@ -309,6 +316,7 @@ class SettingsDialog(QDialog):
             )
             output = result.stdout.strip() or f"Model {model} updated."
             QMessageBox.information(self, "Model Update", output)
+            self.parent.agents_tab.load_global_preferences()
         except FileNotFoundError:
             QMessageBox.warning(self, "Error", "Ollama executable not found.")
         except Exception as e:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -136,6 +136,7 @@ Displays this guide within the application so you can review instructions withou
 Global preferences are available under **Settings**.
 - Toggle dark mode and change your displayed user name and color.
 - Update the Ollama runtime or pull the latest version of a model using the provided buttons.
+- The list of available models is cached so opening the dialog is fast.
 - Errors during updates are shown in a pop‑up message.
 
 ## Configuration Files


### PR DESCRIPTION
## Summary
- cache model list in settings dialog to avoid slow API calls
- refresh the model list only when updating a model
- prevent unnecessary network fetch when closing settings dialog
- document the cached model list behavior in README and user guide

## Testing
- `pip install -r requirements.txt` *(fails: Missing parentheses in call to 'print')*
- `pip install -r requirements-dev.txt`
- `flake8 .` *(fails with many style errors)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684208a1eedc83269edfca8806f0601d