### PR TITLE
Fix tool execution for assistant agents

### DIFF
--- a/message_broker.py
+++ b/message_broker.py
@@ -180,14 +180,13 @@ class MessageBroker:
             if not last_message.endswith(f"Next Response By: {agent_name}"):
                 return
 
-        # Attempt to parse if agent is "Coordinator" or "Specialist" and returned JSON
+        # Attempt to parse JSON responses for any agent when tool use is enabled
         parsed = None
-        if agent_settings.get('role') in ['Coordinator', 'Specialist']:
-            if content.startswith("{") and content.endswith("}"):
-                try:
-                    parsed = json.loads(content)
-                except json.JSONDecodeError:
-                    parsed = None
+        if content.startswith("{") and content.endswith("}"):
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError:
+                parsed = None
 
         if parsed is not None:
             if "tool_request" in parsed:


### PR DESCRIPTION
## Summary
- remove role restriction when parsing JSON tool requests
- add regression test ensuring assistants execute tools when enabled

## Testing
- `flake8 message_broker.py tests/test_message_broker.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68420a1c23dc8326b3a347f04f1ff706