### PR TITLE
Improve desktop automation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
 *   Python 3.7 or higher
 *   PyQt5
 *   Requests
-*   win10toast (required for Windows notification support)
+*   win10toast (only needed on Windows for notification support)
 *   SymPy
 *   A running Ollama instance with the desired language models installed (see [Ollama](https://ollama.ai/))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyQt5
 requests
-win10toast
+win10toast; sys_platform == 'win32'
 sympy

--- a/tests/test_desktop_automation.py
+++ b/tests/test_desktop_automation.py
@@ -25,3 +25,13 @@ def test_move_file(monkeypatch, tmp_path):
     result = da.run_tool({"action": "move", "target": str(src), "destination": str(dst_dir)})
     assert "Moved" in result
     assert moved["args"] == (str(src), str(dst_dir))
+
+
+def test_launch_linux_fallback(monkeypatch):
+    called = {}
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    monkeypatch.setattr(subprocess, "Popen", lambda args: called.setdefault("args", args))
+    result = da.run_tool({"action": "launch", "target": "myapp"})
+    assert "Launched" in result
+    assert called["args"] == ["myapp"]

--- a/tool_plugins/desktop_automation.py
+++ b/tool_plugins/desktop_automation.py
@@ -25,7 +25,11 @@ def run_tool(args):
             elif platform.system() == "Darwin":
                 subprocess.Popen(["open", target])
             else:
-                subprocess.Popen(["xdg-open", target])
+                opener = shutil.which("xdg-open")
+                if opener:
+                    subprocess.Popen([opener, target])
+                else:
+                    subprocess.Popen([target])
             return f"Launched {target}"
         except Exception as e:
             return f"[desktop-automation Error] {e}"


### PR DESCRIPTION
## Summary
- avoid installing `win10toast` on non-Windows platforms
- update README to document Windows-only notifier requirement
- make desktop automation tool fall back when `xdg-open` is unavailable
- add test for the new fallback logic

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_68420d147fdc83269566139b22a35f0b