### PR TITLE
Fix tasks tab empty list handling

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -103,7 +103,7 @@ Agents call tools by returning a JSON block in the format produced by
 ## Tasks Tab
 
 Scheduled prompts appear in both a list and calendar view. Dates with tasks display a red dot and the
-current day is highlighted.
+current day is highlighted. When there are no tasks a message labeled "No tasks available." appears below the calendar.
 
 - **Add Task** – create a prompt for a specific agent. The default due time is one minute from now.
 - **Edit** – change an existing task.

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -98,6 +98,11 @@ class TasksTab(QWidget):
         self.tasks_list.itemDoubleClicked.connect(self.toggle_status_ui)
         self.layout.addWidget(self.tasks_list)
 
+        # Label shown when there are no tasks
+        self.empty_label = QLabel("No tasks available.")
+        self.empty_label.setAlignment(Qt.AlignCenter)
+        self.layout.addWidget(self.empty_label)
+
         # Calendar view
         self.calendar = DroppableCalendarWidget(self)
         self.calendar.activated.connect(self.on_date_activated)
@@ -158,11 +163,11 @@ class TasksTab(QWidget):
         Refresh the tasks list in the UI.
         """
         self.tasks_list.clear()
-        if not self.tasks:  # Check if the list is empty
-            label = QLabel("No tasks available.")
-            label.setAlignment(Qt.AlignCenter)
-            self.layout.addWidget(label)
+        if not self.tasks:
+            self.tasks_list.hide()
+            self.empty_label.show()
         else:
+            self.empty_label.hide()
             for t in self.tasks:
                 item = QListWidgetItem()
                 due_time = t.get("due_time", "")
@@ -173,8 +178,10 @@ class TasksTab(QWidget):
                 repeat_str = f" every {repeat}m" if repeat else ""
                 summary = f"[{due_time}] {agent_name}{repeat_str} ({status}) - {prompt[:30]}..."
                 item.setText(summary)
-                item.setData(Qt.UserRole, t['id'])  # Store the task ID in the item's data
+                item.setData(Qt.UserRole, t['id'])
                 self.tasks_list.addItem(item)
+            self.tasks_list.show()
+
         self.highlight_task_dates()
 
     def highlight_task_dates(self):

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -1,0 +1,25 @@
+import os
+from PyQt5.QtWidgets import QApplication, QLabel
+import tab_tasks
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyApp:
+    def __init__(self):
+        self.tasks = []
+        self.agents_data = []
+        self.debug_enabled = False
+        self.metrics = {}
+
+    def refresh_metrics_display(self):
+        pass
+
+
+def test_refresh_empty_state():
+    app = QApplication.instance() or QApplication([])
+    tab = tab_tasks.TasksTab(DummyApp())
+    tab.refresh_tasks_list()
+    tab.refresh_tasks_list()
+    labels = [w for w in tab.findChildren(QLabel) if w.text() == "No tasks available."]
+    assert len(labels) == 1
+    app.quit()


### PR DESCRIPTION
## Summary
- avoid adding multiple 'No tasks available.' labels
- show/hide a single label when no tasks exist
- document the placeholder message in the user guide
- add regression test for tasks tab refresh

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420d5e8b348326b1343720edf64252