### PR TITLE
Add credential manager tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
         from websites.
     *   Includes a built-in **File Summarizer** tool for generating quick summaries of text files.
     *   Provides a **Desktop Automation** plugin for launching programs or moving files via OS commands.
+    *   Includes a **Credential Manager** plugin for securely storing API keys using the system keyring.
     *   Tools can be updated using the **Edit Tool** button in the Tools tab.
     *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models. Model names are cached so the dialog opens quickly.
 
@@ -212,7 +213,7 @@ args: (optional) List of argument names the tool accepts.
 script: The content of the Python script that implements the tool. The script must define a function called run_tool(args) that takes a dictionary of arguments and returns a string.
 script_path: (optional) Path to a Python file containing the tool implementation. If script_path is missing but script is provided, the application will run the script from a temporary file.
 Tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point
-are loaded automatically on startup. Built-in plugins include `math-solver` for complex calculations.
+are loaded automatically on startup. Built-in plugins include `math-solver` for complex calculations and `credential-manager` for secure credential storage.
 Example:
 
 '''JSON

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -96,6 +96,7 @@ Bundled plugins include:
 - **windows-notifier** – display a Windows 11 notification using `win10toast`.
 - **ar-overlay** – show a small on-screen HUD message for quick reminders.
 - **desktop-automation** – launch programs or move files through OS commands.
+- **credential-manager** – securely store and retrieve credentials via the system keyring.
 
 Agents call tools by returning a JSON block in the format produced by
 `generate_tool_instructions_message()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyQt5
 requests
 win10toast; sys_platform == 'win32'
 sympy
+keyring

--- a/tests/test_credential_manager.py
+++ b/tests/test_credential_manager.py
@@ -1,0 +1,28 @@
+import keyring
+from tool_plugins import credential_manager
+
+
+class MemoryKeyring(keyring.backend.KeyringBackend):
+    priority = 1
+
+    def __init__(self):
+        self.storage = {}
+
+    def get_password(self, service, username):
+        return self.storage.get((service, username))
+
+    def set_password(self, service, username, password):
+        self.storage[(service, username)] = password
+
+    def delete_password(self, service, username):
+        self.storage.pop((service, username), None)
+
+
+def test_store_get_delete():
+    keyring.set_keyring(MemoryKeyring())
+    credential_manager.run_tool({"action": "store", "service": "svc", "username": "u", "value": "secret"})
+    value = credential_manager.run_tool({"action": "get", "service": "svc", "username": "u"})
+    assert value == "secret"
+    credential_manager.run_tool({"action": "delete", "service": "svc", "username": "u"})
+    result = credential_manager.run_tool({"action": "get", "service": "svc", "username": "u"})
+    assert "not found" in result.lower()

--- a/tool_plugins/credential_manager.py
+++ b/tool_plugins/credential_manager.py
@@ -1,0 +1,48 @@
+TOOL_METADATA = {
+    "name": "credential-manager",
+    "description": "Store, retrieve, and delete credentials using the system keyring.",
+    "args": ["action", "service", "username", "value"]
+}
+
+
+def run_tool(args):
+    """Manage credentials with the keyring library.
+
+    Args:
+        args (dict): action ('store', 'get', 'delete'), service name,
+            username, and optional value when storing.
+    """
+    try:
+        import keyring
+    except Exception:
+        return "[credential-manager Error] keyring not installed."
+
+    action = args.get("action")
+    service = args.get("service", "cerebro")
+    username = args.get("username", "default")
+
+    if action == "store":
+        value = args.get("value")
+        if value is None:
+            return "[credential-manager Error] No value provided."
+        try:
+            keyring.set_password(service, username, value)
+            return "Credential stored"
+        except Exception as e:
+            return f"[credential-manager Error] {e}"
+    elif action == "get":
+        try:
+            value = keyring.get_password(service, username)
+            return value if value is not None else "[credential-manager Error] Credential not found."
+        except Exception as e:
+            return f"[credential-manager Error] {e}"
+    elif action == "delete":
+        try:
+            keyring.delete_password(service, username)
+            return "Credential deleted"
+        except keyring.errors.PasswordDeleteError:
+            return "[credential-manager Error] Credential not found."
+        except Exception as e:
+            return f"[credential-manager Error] {e}"
+    else:
+        return "[credential-manager Error] Invalid action."


### PR DESCRIPTION
## Summary
- create `credential-manager` tool that stores credentials in the system keyring
- document the new tool in README and user guide
- update Python dependencies with `keyring`
- add tests for credential manager

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422f9b1b4883269e742537a3a48a6a