### PR TITLE
Add collapsible tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Agents can be granted the ability to use tools.
     *   Tools are implemented as Python scripts that define a `run_tool(args)` function.
     *   Agents can invoke tools by including a specific JSON format in their response.
-    *   When a tool is triggered, the chat shows a 🛠️ icon with the function call and
-        displays the result on a separate line. The output is then sent back to the
-        requesting agent so it can refine its answer.
+    *   When a tool is triggered, the chat displays a 🛠️ icon with the tool name.
+        Expanding the entry reveals the full function call and its result. The
+        output is then sent back to the requesting agent so it can refine its
+        answer.
     *   Each agent has an individual setting to toggle tool usage on or off.
 *   Each agent can enable or disable individual tools.
 *   **Thinking Mode:** When enabled, an agent iteratively generates a series of

--- a/dark_mode.qss
+++ b/dark_mode.qss
@@ -121,6 +121,10 @@ QMainWindow {
     padding-left: 8px;
 }
 
+.toolBlock {
+    margin-left: 20px;
+}
+
 #inputContainer {
     background-color: #333333;
     border-radius: 8px;

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -99,9 +99,9 @@ Bundled plugins include:
 
 Agents call tools by returning a JSON block in the format produced by
 `generate_tool_instructions_message()`.
-When a tool is executed, the conversation view renders a small 🛠️ icon with the
-function call followed by the result on its own line. The agent receives that
-result and can use it when crafting the next reply.
+When a tool is executed, the conversation view shows a 🛠️ icon with the tool
+name. Expanding the entry reveals the full function call and its output. The
+agent receives that result and can use it when crafting the next reply.
 
 ## Tasks Tab
 

--- a/light_mode.qss
+++ b/light_mode.qss
@@ -126,6 +126,10 @@ QMainWindow {
     padding-left: 8px;
 }
 
+.toolBlock {
+    margin-left: 20px;
+}
+
 #inputContainer {
     background-color: #f8f8f8;
     border-radius: 8px;

--- a/message_broker.py
+++ b/message_broker.py
@@ -8,6 +8,7 @@ from tool_utils import (
     generate_tool_instructions_message,
     format_tool_call_html,
     format_tool_result_html,
+    format_tool_block_html,
 )
 from tasks import add_task, delete_task, save_tasks
 from transcripts import (
@@ -251,14 +252,21 @@ class MessageBroker:
                 )
             else:
                 tool_result = run_tool(self.app.tools, tool_name, tool_args, self.app.debug_enabled)
-                call_html = format_tool_call_html(tool_name, tool_args)
+                block_html = format_tool_block_html(tool_name, tool_args, tool_result)
                 self.app.chat_tab.append_message_html(
-                    f"\n[{timestamp}] <span style='color:{agent_color};'>{agent_name}:</span> {call_html}"
+                    f"\n[{timestamp}] <span style='color:{agent_color};'>{agent_name}:</span> {block_html}"
                 )
                 append_message(
                     self.chat_history,
                     "assistant",
                     f"{agent_name} called {tool_name}",
+                    agent_name,
+                    debug_enabled=self.app.debug_enabled if self.app else False,
+                )
+                append_message(
+                    self.chat_history,
+                    "assistant",
+                    tool_result,
                     agent_name,
                     debug_enabled=self.app.debug_enabled if self.app else False,
                 )
@@ -269,18 +277,6 @@ class MessageBroker:
                         self.chat_history,
                         "assistant",
                         error_msg,
-                        agent_name,
-                        debug_enabled=self.app.debug_enabled if self.app else False,
-                    )
-                else:
-                    result_html = format_tool_result_html(tool_result)
-                    self.app.chat_tab.append_message_html(
-                        f"[{timestamp}] <span style='color:{agent_color};'>{result_html}</span>"
-                    )
-                    append_message(
-                        self.chat_history,
-                        "assistant",
-                        tool_result,
                         agent_name,
                         debug_enabled=self.app.debug_enabled if self.app else False,
                     )

--- a/tests/test_tool_utils.py
+++ b/tests/test_tool_utils.py
@@ -43,3 +43,9 @@ def test_format_tool_result_html():
     assert 'ok' in html
     assert 'toolResult' in html
 
+
+def test_format_tool_block_html():
+    html = tool_utils.format_tool_block_html('echo-plugin', {'msg': 'hi'}, 'ok')
+    assert 'echo-plugin' in html
+    assert 'toolBlock' in html
+

--- a/tool_utils.py
+++ b/tool_utils.py
@@ -44,3 +44,15 @@ def format_tool_call_html(tool_name: str, tool_args: Dict[str, Any]) -> str:
 def format_tool_result_html(result: str) -> str:
     """Return HTML snippet for a tool result."""
     return f"<span class='toolResult'>&rarr; {result}</span>"
+
+
+def format_tool_block_html(tool_name: str, tool_args: Dict[str, Any], result: str) -> str:
+    """Return collapsible HTML block for a tool call and its result."""
+    call_html = format_tool_call_html(tool_name, tool_args)
+    result_html = format_tool_result_html(result)
+    return (
+        "<details class='toolBlock'>"
+        f"<summary>\ud83d\udd27 {tool_name}</summary>"
+        f"<div>{call_html}<br>{result_html}</div>"
+        "</details>"
+    )


### PR DESCRIPTION
## Summary
- show tool calls with results inside a collapsible block
- style new tool block in both themes
- document updated behaviour in README and user guide
- add helper for generating tool block HTML
- test new helper

## Testing
- `flake8 .` *(fails: E265 block comment should start with '# ' ...)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684230a5423c8326919ea2b62e03a3e0