### PR TITLE
Add task sequence recorder tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Provides a **Desktop Automation** plugin for launching programs or moving files via OS commands.
     *   Includes a **Credential Manager** plugin for securely storing API keys using the system keyring.
     *   Includes an **Automated Update Manager** plugin for checking for new versions and downloading updates on Windows 11.
+    *   Bundles a **Task Sequence Recorder** plugin to capture mouse and keyboard actions and replay them later.
     *   Tools can be updated using the **Edit Tool** button in the Tools tab.
     *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models. Model names are cached so the dialog opens quickly.
 
@@ -79,6 +80,8 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
 *   Requests
 *   win10toast (only needed on Windows for notification support)
 *   SymPy
+*   pyautogui
+*   pynput
 *   A running Ollama instance with the desired language models installed (see [Ollama](https://ollama.ai/))
 
 ## Installation

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -100,6 +100,7 @@ Bundled plugins include:
 - **credential-manager** – securely store and retrieve credentials via the system keyring.
 - **text-to-speech** – speak text aloud using the system voice.
 - **update-manager** – check for new versions of Cerebro and download updates on Windows 11.
+- **task-sequence-recorder** – record mouse and keyboard events and replay them later.
 
 Agents call tools by returning a JSON block in the format produced by
 `generate_tool_instructions_message()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ sympy
 plyer
 keyring
 pyttsx3
+pyautogui
+pynput

--- a/tests/test_task_sequence_recorder.py
+++ b/tests/test_task_sequence_recorder.py
@@ -1,0 +1,89 @@
+import json
+import sys
+import types
+from tool_plugins import task_sequence_recorder as tsr
+
+
+def test_record_and_play(tmp_path, monkeypatch):
+    events = []
+
+    class FakeMouseListener:
+        def __init__(self, on_move=None, on_click=None):
+            self.on_move = on_move
+            self.on_click = on_click
+            self.running = True
+
+        def __enter__(self):
+            if self.on_move:
+                self.on_move(10, 20)
+            if self.on_click:
+                FakeButton = type("Button", (), {"name": "left"})
+                self.on_click(10, 20, FakeButton(), True)
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeKeyboardListener:
+        def __init__(self, on_press=None, on_release=None):
+            self.on_press = on_press
+            self.on_release = on_release
+            self.running = True
+
+        def __enter__(self):
+            if self.on_press:
+                self.on_press("a")
+            if self.on_release:
+                self.on_release("a")
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    fake_pynput = types.SimpleNamespace(
+        mouse=types.SimpleNamespace(Listener=FakeMouseListener),
+        keyboard=types.SimpleNamespace(Listener=FakeKeyboardListener, Key=types.SimpleNamespace(esc="esc")),
+    )
+    monkeypatch.setitem(sys.modules, "pynput", fake_pynput)
+    monkeypatch.setattr(tsr.time, "sleep", lambda s: None)
+
+    path = tmp_path / "seq.json"
+    result = tsr.run_tool({"action": "record", "path": str(path), "duration": 0})
+    assert "Sequence recorded" in result
+    data = json.loads(path.read_text())
+    assert any(e["type"] == "move" for e in data)
+
+    actions = []
+    fake_pg = types.SimpleNamespace(
+        moveTo=lambda x, y: actions.append(("move", x, y)),
+        click=lambda x, y, button="left": actions.append(("click", x, y, button)),
+        keyDown=lambda k: actions.append(("down", k)),
+        keyUp=lambda k: actions.append(("up", k)),
+    )
+    monkeypatch.setitem(sys.modules, "pyautogui", fake_pg)
+
+    result = tsr.run_tool({"action": "play", "path": str(path)})
+    assert "Sequence played" in result
+    assert any(a[0] == "move" for a in actions)
+
+
+def test_missing_modules(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynput", types.ModuleType("pynput"))
+    result = tsr.run_tool({"action": "record"})
+    assert "pynput not installed" in result
+
+    import builtins
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pyautogui":
+            raise ImportError("missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    path = "dummy.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump([], f)
+    result = tsr.run_tool({"action": "play", "path": path})
+    assert "pyautogui not installed" in result

--- a/tool_plugins/task_sequence_recorder.py
+++ b/tool_plugins/task_sequence_recorder.py
@@ -1,0 +1,87 @@
+TOOL_METADATA = {
+    "name": "task-sequence-recorder",
+    "description": "Record mouse clicks and keystrokes then replay them later.",
+    "args": ["action", "path", "duration"],
+}
+
+import json
+import time
+
+
+def run_tool(args):
+    """Record or replay a sequence of user input events."""
+    action = args.get("action")
+    path = args.get("path", "sequence.json")
+    duration = float(args.get("duration", 5))
+
+    if action == "record":
+        try:
+            from pynput import mouse, keyboard
+        except Exception:
+            return "[task-sequence-recorder Error] pynput not installed."
+        events = []
+        start = time.time()
+
+        def on_move(x, y):
+            events.append({"type": "move", "x": x, "y": y, "time": time.time() - start})
+
+        def on_click(x, y, button, pressed):
+            events.append({
+                "type": "click",
+                "x": x,
+                "y": y,
+                "button": getattr(button, "name", str(button)),
+                "pressed": pressed,
+                "time": time.time() - start,
+            })
+
+        def on_press(key):
+            events.append({"type": "press", "key": str(key), "time": time.time() - start})
+
+        def on_release(key):
+            events.append({"type": "release", "key": str(key), "time": time.time() - start})
+            if key == keyboard.Key.esc:
+                return False
+
+        with mouse.Listener(on_move=on_move, on_click=on_click) as ml, \
+                keyboard.Listener(on_press=on_press, on_release=on_release) as kl:
+            end = time.time() + duration
+            while time.time() < end and ml.running and kl.running:
+                time.sleep(0.01)
+
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(events, f)
+            return f"Sequence recorded to {path}"
+        except Exception as exc:
+            return f"[task-sequence-recorder Error] {exc}"
+
+    if action == "play":
+        try:
+            import pyautogui
+        except Exception:
+            return "[task-sequence-recorder Error] pyautogui not installed."
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                events = json.load(f)
+        except Exception as exc:
+            return f"[task-sequence-recorder Error] {exc}"
+        last = 0
+        for evt in events:
+            delay = evt.get("time", 0) - last
+            if delay > 0:
+                time.sleep(delay)
+            last = evt.get("time", 0)
+            if evt["type"] == "move":
+                pyautogui.moveTo(evt["x"], evt["y"])
+            elif evt["type"] == "click" and evt.get("pressed"):
+                pyautogui.click(evt["x"], evt["y"], button=evt.get("button", "left"))
+            elif evt["type"] == "press":
+                key = evt["key"].replace("'", "")
+                pyautogui.keyDown(key)
+            elif evt["type"] == "release":
+                key = evt["key"].replace("'", "")
+                pyautogui.keyUp(key)
+        return "Sequence played"
+
+    return "[task-sequence-recorder Error] Unknown action"


### PR DESCRIPTION
## Summary
- add Task Sequence Recorder tool plugin
- document the new plugin in README and user guide
- update requirements with pyautogui and pynput
- add tests for the new tool

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684231fd6aac8326a16161ff9b3f1097