### PR TITLE
Improve tool script editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Includes a **Credential Manager** plugin for securely storing API keys using the system keyring.
     *   Includes an **Automated Update Manager** plugin for checking for new versions and downloading updates on Windows 11.
     *   Tools can be updated using the **Edit Tool** button in the Tools tab.
+    *   The Tool script editor features Python syntax highlighting when QScintilla is installed.
     *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models. Model names are cached so the dialog opens quickly.
 
 *   **Task Scheduling:**
@@ -112,6 +113,7 @@ Open the "Docs" tab or press `Ctrl+6` to view the full user guide.
     ```bash
     pip install -r requirements.txt
     ```
+    QScintilla is optional but enables syntax highlighting in the tool editor.
 
 5.  *(Optional)* **Install the Ollama runtime and a model:**
 

--- a/dialogs.py
+++ b/dialogs.py
@@ -20,6 +20,37 @@ from PyQt5.QtWidgets import (
 import subprocess
 from PyQt5.QtCore import Qt, QDateTime
 
+try:
+    from PyQt5.Qsci import QsciScintilla, QsciLexerPython
+
+    class CodeEditor(QsciScintilla):
+        """A simple Python code editor with syntax highlighting."""
+
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            self.setUtf8(True)
+            self.setMarginsBackgroundColor(Qt.lightGray)
+            self.setMarginType(0, QsciScintilla.NumberMargin)
+            self.setMarginWidth(0, "0000")
+            lexer = QsciLexerPython()
+            self.setLexer(lexer)
+
+        def text(self):  # compatibility with QTextEdit
+            return QsciScintilla.text(self)
+
+        def set_text(self, text):
+            self.setText(text)
+
+except Exception:  # QScintilla not installed
+    class CodeEditor(QTextEdit):
+        """Fallback plain text editor used when QScintilla is unavailable."""
+
+        def text(self):
+            return self.toPlainText()
+
+        def set_text(self, text):
+            self.setPlainText(text)
+
 class ToolDialog(QDialog):
     # Updated Sample Script
     SAMPLE_SCRIPT = """\"\"\"
@@ -62,8 +93,8 @@ def run_tool(args):
 
         # Script (using a code editor with syntax highlighting)
         layout.addWidget(QLabel("Script (must define `run_tool(args)`):"))
-        self.script_edit = QTextEdit()  # Consider using a proper code editor widget (see notes)
-        self.script_edit.setPlainText(script if script is not None else self.SAMPLE_SCRIPT)
+        self.script_edit = CodeEditor()
+        self.script_edit.set_text(script if script is not None else self.SAMPLE_SCRIPT)
         self.script_edit.setToolTip(
             "Enter the Python script for the tool. It must define a `run_tool(args)` function."
         )
@@ -79,7 +110,7 @@ def run_tool(args):
         return (
             self.name_edit.text().strip(),
             self.description_edit.text().strip(),
-            self.script_edit.toPlainText().strip()
+            self.script_edit.text().strip()
         )
 
     def accept(self):

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -88,6 +88,7 @@ Tools extend Cerebro with custom Python scripts that agents can invoke. The tab 
 2. **Edit Tool** – modify an existing tool.
 3. **Delete** – remove a tool and its script file.
 4. **Run** – execute a tool manually with JSON arguments.
+   The script editor supports Python syntax highlighting when QScintilla is installed.
 
 Bundled plugins include:
 - **file-summarizer** – create a short summary of a text file or provided text.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sympy
 plyer
 keyring
 pyttsx3
+QScintilla

--- a/tests/test_code_editor.py
+++ b/tests/test_code_editor.py
@@ -1,0 +1,23 @@
+import os
+from PyQt5.QtWidgets import QApplication
+import dialogs
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+def test_code_editor_roundtrip():
+    app = QApplication.instance() or QApplication([])
+    editor = dialogs.CodeEditor()
+    test_text = "print('hello')"
+    if hasattr(editor, "set_text"):
+        editor.set_text(test_text)
+    elif hasattr(editor, "setPlainText"):
+        editor.setPlainText(test_text)
+    else:
+        editor.setText(test_text)
+
+    if hasattr(editor, "text"):
+        result = editor.text()
+    else:
+        result = editor.toPlainText()
+    assert "hello" in result
+    app.quit()


### PR DESCRIPTION
## Summary
- use QScintilla for syntax-highlighting in tool editor when available
- add optional QScintilla dependency
- document improved script editor in README and user guide
- test CodeEditor widget

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842351441448326960cc7d3d11639ae