### PR TITLE
Add filtering and row actions to tasks tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Agents can schedule tasks to be executed at a specific time. New tasks default to one minute from the current time.
     *   Tasks are stored in `tasks.json`.
     *   Tasks appear on a drag-and-drop calendar for easy rescheduling and completion.
+    *   Filter tasks by agent or status using drop-down menus above the list.
+    *   Each row contains Edit, Delete and Complete buttons for quick changes.
     *   Tasks can optionally repeat at a set interval.
     *   Due times must be in ISO 8601 format or `YYYY-MM-DD HH:MM:SS` local time.
         Today's date is highlighted and any date with tasks shows a small red dot.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -116,6 +116,8 @@ current day is highlighted. When there are no tasks a message labeled "No tasks 
 - **Edit** – change an existing task.
 - **Delete** – remove a task after confirmation.
 - **Toggle Status** – mark the selected task as completed or pending.
+- **Filters** – drop-down menus allow filtering by agent or status.
+- **Row Actions** – each task row includes Edit, Delete and Complete buttons.
 - **Repeat Interval** – optional number of minutes after which the task should repeat.
 - **Time Format** – enter times as ISO 8601 (YYYY-MM-DDTHH:MM:SS) or `YYYY-MM-DD HH:MM:SS` local time.
 

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -1,5 +1,5 @@
 import os
-from PyQt5.QtWidgets import QApplication, QLabel
+from PyQt5.QtWidgets import QApplication, QLabel, QPushButton
 import tab_tasks
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -7,7 +7,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 class DummyApp:
     def __init__(self):
         self.tasks = []
-        self.agents_data = []
+        self.agents_data = {}
         self.debug_enabled = False
         self.metrics = {}
 
@@ -22,4 +22,29 @@ def test_refresh_empty_state():
     tab.refresh_tasks_list()
     labels = [w for w in tab.findChildren(QLabel) if w.text() == "No tasks available."]
     assert len(labels) == 1
+    app.quit()
+
+
+def test_filters_and_row_actions():
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    dummy.agents_data = {"a1": {}, "a2": {}}
+    dummy.tasks = [
+        {"id": "1", "agent_name": "a1", "prompt": "p1", "due_time": "2024-01-01", "status": "pending", "repeat_interval": 0},
+        {"id": "2", "agent_name": "a2", "prompt": "p2", "due_time": "2024-01-01", "status": "completed", "repeat_interval": 0},
+    ]
+    tab = tab_tasks.TasksTab(dummy)
+
+    tab.agent_filter.setCurrentText("a1")
+    tab.refresh_tasks_list()
+    assert tab.tasks_list.count() == 1
+
+    tab.status_filter.setCurrentText("completed")
+    tab.agent_filter.setCurrentText("All Agents")
+    tab.refresh_tasks_list()
+    assert tab.tasks_list.count() == 1
+
+    item_widget = tab.tasks_list.itemWidget(tab.tasks_list.item(0))
+    buttons = item_widget.findChildren(QPushButton)
+    assert len(buttons) == 3
     app.quit()


### PR DESCRIPTION
## Summary
- filter tasks by agent or status
- add row-level edit/delete/complete buttons
- document updated task features
- test new UI helpers

## Testing
- `flake8 .` *(fails: E265 block comment should start with '# ' ...)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842352c196c8326b37f22f6e48108dc