### PR TITLE
Add conversation search

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Chat History Management:**
     *   Each session begins with a blank conversation.
     *   History can be exported or cleared from the chat menu if desired.
+    *   Click the 🔍 icon to search within the current conversation.
 *   **Conversation Summaries:**
     *   Older messages are automatically condensed when a chat grows large to
         keep prompts short.

--- a/dialogs.py
+++ b/dialogs.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QMessageBox,
     QSpinBox,
+    QListWidget,
 )
 import subprocess
 from PyQt5.QtCore import Qt, QDateTime
@@ -321,4 +322,48 @@ class SettingsDialog(QDialog):
             QMessageBox.warning(self, "Error", "Ollama executable not found.")
         except Exception as e:
             QMessageBox.warning(self, "Error", f"Failed to update model: {e}")
+
+
+class SearchDialog(QDialog):
+    """Dialog for searching conversation history."""
+
+    def __init__(self, parent, conversation_text):
+        super().__init__(parent)
+        self.setWindowTitle("Search Conversation")
+        self.conversation_lines = conversation_text.splitlines()
+
+        layout = QVBoxLayout(self)
+
+        self.search_input = QLineEdit()
+        self.search_input.setPlaceholderText("Type to search...")
+        layout.addWidget(self.search_input)
+
+        self.results_list = QListWidget()
+        layout.addWidget(self.results_list)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.Close)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+        self.search_input.textChanged.connect(self.update_results)
+
+    def update_results(self):
+        query = self.search_input.text().strip().lower()
+        self.results_list.clear()
+        if not query:
+            return
+        for line in self.conversation_lines:
+            if query in line.lower():
+                self.results_list.addItem(line.strip())
+
+
+def filter_messages(conversation_text, query):
+    """Return conversation lines containing the query."""
+    if not query:
+        return []
+    return [
+        line
+        for line in conversation_text.splitlines()
+        if query.lower() in line.lower()
+    ]
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -49,6 +49,7 @@ The Chat tab is the primary interface for interacting with your agents.
   shown.
 - Use the menu in the upper‑right corner to copy, export or clear the conversation history. Each
   session starts with a clean slate.
+- Use the 🔍 button to search the current conversation.
 - When many messages accumulate they are automatically summarized so prompts remain short.
 
 Agents with *desktop history* enabled attach recent screenshots at a configurable interval. This helps

--- a/tab_chat.py
+++ b/tab_chat.py
@@ -6,6 +6,8 @@ from PyQt5.QtWidgets import (
     QLabel, QSplitter, QFrame, QScrollArea, QToolButton, QMenu, QAction
 )
 
+from dialogs import SearchDialog
+
 class ChatTab(QWidget):
     """
     Encapsulates the chat UI: display, input, send/clear buttons.
@@ -219,8 +221,13 @@ class ChatTab(QWidget):
         self.chat_display.verticalScrollBar().setValue(self.chat_display.verticalScrollBar().maximum())
     
     def show_search(self):
-        """Show search interface in chat"""
-        self.parent_app.show_notification("Search functionality coming soon", "info")
+        """Display a dialog to search conversation history."""
+        text = self.chat_display.toPlainText()
+        if not text.strip():
+            self.parent_app.show_notification("No conversation to search", "info")
+            return
+        dialog = SearchDialog(self, text)
+        dialog.exec_()
     
     def copy_conversation(self):
         """Copy conversation to clipboard"""

--- a/tests/test_chat_search.py
+++ b/tests/test_chat_search.py
@@ -1,0 +1,9 @@
+from dialogs import filter_messages
+
+
+def test_filter_messages():
+    text = "Hello\nWorld\nFoo bar"
+    assert filter_messages(text, "foo") == ["Foo bar"]
+    assert filter_messages(text, "o") == ["Hello", "World", "Foo bar"]
+    assert filter_messages(text, "") == []
+


### PR DESCRIPTION
## Summary
- implement `SearchDialog` in `dialogs.py`
- expose search via `show_search` in chat tab
- document search feature in README and user guide
- test conversation filtering logic

## Testing
- `flake8 .` *(fails: E501 and other issues)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842353d49b88326b5fbf3a5792b3e63