### PR TITLE
Enable saving conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Tasks can register with the operating system's scheduler so they run even when Cerebro is closed. Windows 11 uses **Task Scheduler** and Unix-like systems rely on `cron`.
     *   The included **Windows Notifier** tool can display Windows 11 notifications when a scheduled task runs.
 *   **Chat History Management:**
-    *   Each session begins with a blank conversation.
-    *   History can be exported or cleared from the chat menu if desired.
+*   Each session begins with a blank conversation.
+*   History can be saved, exported or cleared from the chat menu if desired.
 *   **Conversation Summaries:**
     *   Older messages are automatically condensed when a chat grows large to
         keep prompts short.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -47,7 +47,7 @@ The Chat tab is the primary interface for interacting with your agents.
 - Enter a prompt at the bottom and press **Send**.
 - Messages appear in a scrollable pane. While an agent is generating a reply, a "typing" indicator is
   shown.
-- Use the menu in the upper‑right corner to copy, export or clear the conversation history. Each
+- Use the menu in the upper‑right corner to copy, save, export or clear the conversation history. Each
   session starts with a clean slate.
 - When many messages accumulate they are automatically summarized so prompts remain short.
 

--- a/tab_chat.py
+++ b/tab_chat.py
@@ -3,7 +3,8 @@ from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QTextEdit, QPushButton, QHBoxLayout, QStyle,
-    QLabel, QSplitter, QFrame, QScrollArea, QToolButton, QMenu, QAction
+    QLabel, QSplitter, QFrame, QScrollArea, QToolButton, QMenu, QAction,
+    QFileDialog
 )
 
 class ChatTab(QWidget):
@@ -230,9 +231,30 @@ class ChatTab(QWidget):
         self.parent_app.show_notification("Conversation copied to clipboard", "info")
     
     def save_conversation(self):
-        """Save conversation to a file"""
-        # This would normally open a file dialog, but for simplicity we'll just notify
-        self.parent_app.show_notification("Save functionality coming soon", "info")
+        """Save conversation to a text file chosen by the user."""
+        text = self.chat_display.toPlainText()
+        if not text.strip():
+            self.parent_app.show_notification("Nothing to save", "info")
+            return
+
+        options = QFileDialog.Options()
+        options |= QFileDialog.DontUseNativeDialog
+        file_name, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Conversation",
+            "conversation.txt",
+            "Text Files (*.txt);;All Files (*)",
+            options=options,
+        )
+        if not file_name:
+            return
+
+        try:
+            with open(file_name, "w", encoding="utf-8") as f:
+                f.write(text)
+            self.parent_app.show_notification(f"Conversation saved to {file_name}")
+        except Exception as e:  # pragma: no cover - just in case
+            self.parent_app.show_notification(f"Failed to save conversation: {e}", "error")
     
     def show_typing_indicator(self):
         """Show the typing indicator with animated dots"""

--- a/tests/test_tab_chat.py
+++ b/tests/test_tab_chat.py
@@ -1,0 +1,33 @@
+import os
+from PyQt5.QtWidgets import QApplication
+import tab_chat
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyApp:
+    def __init__(self):
+        self.notifications = []
+    def show_notification(self, message, type="info"):
+        self.notifications.append((message, type))
+    def export_chat_histories(self):
+        pass
+    def clear_chat_histories(self):
+        pass
+    def clear_chat(self):
+        pass
+    def send_message(self, msg):
+        pass
+
+
+def test_save_conversation(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    tab = tab_chat.ChatTab(dummy)
+    tab.chat_display.setPlainText("hello world")
+    dest = tmp_path / "conv.txt"
+    monkeypatch.setattr(tab_chat.QFileDialog, "getSaveFileName", lambda *a, **k: (str(dest), "txt"))
+    tab.save_conversation()
+    with open(dest, "r", encoding="utf-8") as f:
+        assert f.read() == "hello world"
+    assert dummy.notifications
+    app.quit()


### PR DESCRIPTION
## Summary
- allow users to save conversations to a text file
- document the new Save option in README and user guide
- test saving a chat in `test_tab_chat`

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842354a4ec88326b7ba9ff649bdd4d7