### PR TITLE
Add accent color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
         Screens are captured at each agent's `screenshot_interval` and sent to the model as base64 images.
 *   **Customizable UI:**
     *   Light and dark mode support.
-    *   Configurable user name and color.
+    *   Configurable user name, chat color and accent color.
 *   **Debug Mode:**
     *   Enables verbose logging for debugging purposes.
 *   **Metrics Dashboard:**
@@ -205,6 +205,7 @@ include_screenshot: Deprecated.
 image_path: Currently unused.
 user_name: The user's display name.
 user_color: The user's chat message color.
+accent_color: The primary UI accent color used in the application theme.
 dark_mode: Enables dark mode (boolean).
 tools.json
 This file defines available tools.

--- a/app.py
+++ b/app.py
@@ -15,6 +15,8 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QKeySequence
 
+from theme_utils import load_style_sheet
+
 from worker import AIWorker
 from tools import load_tools, run_tool
 from tasks import load_tasks, save_tasks, add_task, delete_task, update_task_due_time
@@ -67,6 +69,7 @@ class AIChatApp(QMainWindow):
         self.current_agent_color = "#000000"
         self.user_name = "You"
         self.user_color = "#0000FF"
+        self.accent_color = "#803391"
         self.dark_mode = False
         self.screenshot_manager = ScreenshotManager()
         self.active_worker_threads = []
@@ -425,6 +428,7 @@ class AIChatApp(QMainWindow):
             self.dark_mode = settings_data["dark_mode"]
             self.user_name = settings_data["user_name"]
             self.user_color = settings_data["user_color"]
+            self.accent_color = settings_data.get("accent_color", self.accent_color)
             self.debug_enabled = settings_data["debug_enabled"]
             self.apply_updated_styles()
             self.agents_tab.update_model_dropdown()
@@ -1197,6 +1201,7 @@ class AIChatApp(QMainWindow):
             "image_path": "",
             "user_name": self.user_name,
             "user_color": self.user_color,
+            "accent_color": self.accent_color,
             "dark_mode": self.dark_mode
         }
         try:
@@ -1218,6 +1223,7 @@ class AIChatApp(QMainWindow):
                 self.include_screenshot = settings.get("include_screenshot", False)
                 self.user_name = settings.get("user_name", "You")
                 self.user_color = settings.get("user_color", "#0000FF")
+                self.accent_color = settings.get("accent_color", "#803391")
                 self.dark_mode = settings.get("dark_mode", False)
                 if self.debug_enabled:
                     print("[Debug] Settings loaded.")
@@ -1230,13 +1236,11 @@ class AIChatApp(QMainWindow):
     # Dark/Light Mode
     # -------------------------------------------------------------------------
     def apply_dark_mode_style(self):
-        with open("dark_mode.qss", "r") as f:
-            style_sheet = f.read()
+        style_sheet = load_style_sheet("dark_mode.qss", self.accent_color)
         self.setStyleSheet(style_sheet)
 
     def apply_light_mode_style(self):
-        with open("light_mode.qss", "r") as f:
-            style_sheet = f.read()
+        style_sheet = load_style_sheet("light_mode.qss", self.accent_color)
         self.setStyleSheet(style_sheet)
 
     # -------------------------------------------------------------------------

--- a/dark_mode.qss
+++ b/dark_mode.qss
@@ -25,7 +25,7 @@ QMainWindow {
 #appLogo {
     font-size: 24px;
     font-weight: bold;
-    color: #803391; /* Purple accent color */
+    color: {ACCENT_COLOR};
 }
 
 #appTagline {
@@ -48,7 +48,7 @@ QMainWindow {
 
 #navButton[selected="true"] {
     background-color: #3d3d3d;
-    border-left: 4px solid #803391; /* Purple accent color */
+    border-left: 4px solid {ACCENT_COLOR};
     font-weight: bold;
 }
 
@@ -146,7 +146,7 @@ QMainWindow {
 }
 
 #sendButton, #clearButton {
-    background-color: #803391; /* Purple accent color */
+    background-color: {ACCENT_COLOR};
     color: white;
     border: none;
     padding: 8px 15px;
@@ -223,7 +223,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     background-color: #2a2a2a;
-    border-top: 2px solid #803391;
+    border-top: 2px solid {ACCENT_COLOR};
     color: #ffffff;
 }
 

--- a/dialogs.py
+++ b/dialogs.py
@@ -219,6 +219,14 @@ class SettingsDialog(QDialog):
         self.user_color_button.setToolTip("Select your user color.")
         self.user_color_button.clicked.connect(self.select_user_color)
         layout.addWidget(self.user_color_button)
+
+        # Accent Color
+        layout.addWidget(QLabel("Accent Color:"))
+        self.accent_color_button = QPushButton()
+        self.accent_color_button.setStyleSheet(f"background-color: {self.parent.accent_color}")
+        self.accent_color_button.setToolTip("Select accent color.")
+        self.accent_color_button.clicked.connect(self.select_accent_color)
+        layout.addWidget(self.accent_color_button)
         
         # Debug Enabled
         self.debug_enabled_checkbox = QCheckBox("Debug Enabled")
@@ -265,11 +273,18 @@ class SettingsDialog(QDialog):
             self.user_color_button.setStyleSheet(f"background-color: {color.name()}")
             self.parent.user_color = color.name()
 
+    def select_accent_color(self):
+        color = QColorDialog.getColor()
+        if color.isValid():
+            self.accent_color_button.setStyleSheet(f"background-color: {color.name()}")
+            self.parent.accent_color = color.name()
+
     def get_data(self):
         return {
             "dark_mode": self.dark_mode_checkbox.isChecked(),
             "user_name": self.user_name_edit.text().strip(),
             "user_color": self.parent.user_color,  # Color is already updated
+            "accent_color": self.parent.accent_color,
             "debug_enabled": self.debug_enabled_checkbox.isChecked()
         }
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -143,7 +143,7 @@ Displays this guide within the application so you can review instructions withou
 ## Settings Dialog
 
 Global preferences are available under **Settings**.
-- Toggle dark mode and change your displayed user name and color.
+- Toggle dark mode and change your displayed user name, chat color and accent color.
 - Update the Ollama runtime or pull the latest version of a model using the provided buttons.
 - The list of available models is cached so opening the dialog is fast.
 - Errors during updates are shown in a pop‑up message.

--- a/light_mode.qss
+++ b/light_mode.qss
@@ -18,7 +18,7 @@ QMainWindow {
 }
 
 #logoContainer {
-    background-color: #803391; /* Purple accent color */
+    background-color: {ACCENT_COLOR};
     border-bottom: 1px solid #e0e0e0;
 }
 
@@ -50,9 +50,9 @@ QMainWindow {
 
 #navButton[selected="true"] {
     background-color: #f0f0f0;
-    border-left: 4px solid #803391; /* Purple accent color */
+    border-left: 4px solid {ACCENT_COLOR};
     font-weight: bold;
-    color: #803391;
+    color: {ACCENT_COLOR};
 }
 
 /* Content area styling */
@@ -152,7 +152,7 @@ QMainWindow {
 }
 
 #sendButton, #clearButton {
-    background-color: #803391; /* Purple accent color */
+    background-color: {ACCENT_COLOR};
     color: white;
     border: none;
     padding: 8px 15px;
@@ -230,7 +230,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     background-color: #ffffff;
-    border-top: 2px solid #803391;
+    border-top: 2px solid {ACCENT_COLOR};
     color: #333333;
 }
 

--- a/tests/test_theme_utils.py
+++ b/tests/test_theme_utils.py
@@ -1,0 +1,7 @@
+from theme_utils import load_style_sheet
+
+def test_load_style_sheet_replaces_placeholder(tmp_path):
+    qss_file = tmp_path / "test.qss"
+    qss_file.write_text("QWidget { color: {ACCENT_COLOR}; }")
+    result = load_style_sheet(str(qss_file), "#123456")
+    assert "#123456" in result

--- a/theme_utils.py
+++ b/theme_utils.py
@@ -1,0 +1,8 @@
+"""Utilities for theme management."""
+
+
+def load_style_sheet(path: str, accent_color: str) -> str:
+    """Return stylesheet with the accent color substituted."""
+    with open(path, "r") as f:
+        style = f.read()
+    return style.replace("{ACCENT_COLOR}", accent_color)


### PR DESCRIPTION
## Summary
- allow specifying UI accent color via settings dialog
- replace hard-coded values in QSS files with a {ACCENT_COLOR} placeholder
- apply stylesheets using new `theme_utils.load_style_sheet` helper
- document accent color settings in README and user guide
- test stylesheet placeholder replacement

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68423570593c8326a0e2820d015ff330