### PR TITLE
Clarify tool result flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Tools are implemented as Python scripts that define a `run_tool(args)` function.
     *   Agents can invoke tools by including a specific JSON format in their response.
     *   When a tool is triggered, the chat displays a 🛠️ icon with the tool name.
-        Expanding the entry reveals the full function call and its result. The
-        output is then sent back to the requesting agent so it can refine its
-        answer.
+        Expanding the entry reveals the call and its result. The result becomes
+        the next user message for the requesting agent so it can refine its
+        answer and share the output when appropriate.
     *   Each agent has an individual setting to toggle tool usage on or off.
 *   Each agent can enable or disable individual tools.
 *   **Thinking Mode:** When enabled, an agent iteratively generates a series of

--- a/app.py
+++ b/app.py
@@ -792,7 +792,7 @@ class AIChatApp(QMainWindow):
                     )
                     # Send the tool result back to the agent for a follow up
                     self.send_message_to_agent(
-                        agent_name, f"Tool {tool_name} result:\n{tool_result}"
+                        agent_name, tool_result
                     )
                     self.show_notification(
                         f"Tool executed successfully: {tool_name}", "info"

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -107,8 +107,9 @@ Bundled plugins include:
 Agents call tools by returning a JSON block in the format produced by
 `generate_tool_instructions_message()`.
 When a tool is executed, the conversation view shows a 🛠️ icon with the tool
-name. Expanding the entry reveals the full function call and its output. The
-agent receives that result and can use it when crafting the next reply.
+name. Expanding the entry reveals the call and its output. That output becomes
+the next user message for the requesting agent, which should incorporate the
+result into its response if it is relevant to the user.
 
 ## Tasks Tab
 

--- a/message_broker.py
+++ b/message_broker.py
@@ -510,12 +510,11 @@ class MessageBroker:
 
     def deliver_tool_result(self, agent_name, tool_name, result):
         """Send a tool's output back to the requesting agent."""
-        info = f"Tool {tool_name} result:\n{result}"
         append_message(
             self.chat_history,
             "user",
-            info,
+            result,
             debug_enabled=self.app.debug_enabled if self.app else False,
         )
         # Route as if coming from a Coordinator so Specialists can receive it
-        self._route_message("Coordinator", agent_name, info)
+        self._route_message("Coordinator", agent_name, result)

--- a/tests/test_app_tool_result.py
+++ b/tests/test_app_tool_result.py
@@ -57,4 +57,4 @@ def test_worker_finished_sends_result_back(monkeypatch):
     app.AIChatApp.worker_finished_sequential(dummy, worker, thread, 'agent1', None, None)
 
     assert sent['agent'] == 'agent1'
-    assert 'Tool echo-plugin result' in sent['msg']
+    assert sent['msg'] == 'ok'

--- a/tool_utils.py
+++ b/tool_utils.py
@@ -29,6 +29,8 @@ def generate_tool_instructions_message(app: Any, agent_name: str) -> str:
             ' }\n'
             '}\n'
             "No extra text outside this JSON when calling a tool.\n"
+            "After a non-silent tool call you will get the tool's result as the next user message.\n"
+            "Include that result in your reply if it's meant for the user.\n"
             f"Available tools:\n{tool_list_str}"
         )
         return instructions


### PR DESCRIPTION
## Summary
- instruct agents that tool results arrive as the next user message
- send only tool result back to the agent
- update docs for new behavior
- adjust tool result test

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423ccb99d48326b06da38093bd159d