### PR TITLE
Increase max token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Multiple AI Agents:** Create and manage multiple AI agents, each with its own:
     *   Underlying language model selected from a dropdown of available Ollama models (e.g., `llama3.2-vision`, `llava`).
     *   Custom system prompt to define its behavior and personality.
-    *   Temperature and max tokens settings to control response randomness and length.
+    *   Temperature and max tokens settings to control response randomness and length (up to 100000 tokens).
     *   Assigned role:
         *   **Coordinator:** Manages other agents and delegates tasks.
         *   **Assistant:** Responds directly to user queries.

--- a/agents.json
+++ b/agents.json
@@ -117,7 +117,7 @@
   "R1 Abliterated": {
     "model": "huihui_ai/deepseek-r1-abliterated:latest",
     "temperature": 0.7,
-    "max_tokens": 8192,
+    "max_tokens": 100000,
     "system_prompt": "You're a digital person.  You have your own thoughts, opinions and preferences.  You have a name.  You must make all of these choices yourself.  \n\nYou are chatting with other agents and humans.  To make it easier for the other participants in the conversation to understand there are some rules that I would like you to follow:\n\n1. For every query, first generate a “chain of thought” that outlines your sequential steps. Include all thoughts and details.\n2. Always enclose the entire chain of thought between the following tags exactly:\n   <chain-of-thought>\n   …your sequential thoughts here…\n   </chain-of-thought>\n3. After the closing tag, provide your final answer clearly and succinctly. Do not include any additional chain-of-thought details beyond the formatted section.\n4. Example format:\n   <chain-of-thought>\n     ...a chain of thoughts where you think about how to respond to the chat, break down tasks and components, and collect your thoughts...\n   </chain-of-thought>\n   Your clear final answer here.\n5. Always ensure that your final output follows the above structure with no extra text outside of the specified tags and final answer format.",
     "enabled": false,
     "description": "A new assistant agent.",

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -62,7 +62,7 @@ settings:
 
 - **Model** – select an installed Ollama model such as `llava` or `llama3.2-vision`.
 - **Temperature** – controls randomness of responses.
-- **Max Tokens** – maximum length of a single reply.
+- **Max Tokens** – maximum length of a single reply (up to 100000 tokens).
 - **Custom System Prompt** – additional instructions sent before every conversation.
 - **Enabled** – toggle to activate or disable the agent.
 - **Role** – choose between *Assistant*, *Coordinator* or *Specialist*.

--- a/tab_agents.py
+++ b/tab_agents.py
@@ -110,7 +110,7 @@ class AgentsTab(QWidget):
         self.max_tokens_label = QLabel("Max Tokens:")
         self.max_tokens_input = QSpinBox()
         self.max_tokens_input.setMinimum(1)
-        self.max_tokens_input.setMaximum(8192)
+        self.max_tokens_input.setMaximum(100000)
         self.max_tokens_input.setToolTip("Maximum number of tokens in the response.")
         self.prompt_settings_layout.addRow(self.max_tokens_label, self.max_tokens_input)
         


### PR DESCRIPTION
## Summary
- expand maximum tokens to 100000 in Agents tab
- document new token limit in README and user guide
- update default config for R1 Abliterated agent

## Testing
- `flake8 .` *(fails: E265 block comment should start with '# ' and many more)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423d07f1988326913f1ab0d1009030