### PR TITLE
Fix Windows notification crash

### DIFF
--- a/tests/test_notification_hub.py
+++ b/tests/test_notification_hub.py
@@ -1,4 +1,5 @@
 from tool_plugins import notification_hub as nh
+import sys
 
 
 def test_run_tool(monkeypatch):
@@ -14,4 +15,18 @@ def test_run_tool(monkeypatch):
     result = nh.run_tool({"title": "Hi", "message": "Test", "push_url": "http://x"})
     assert isinstance(result, str)
     assert sent == [("http://x", {"title": "Hi", "message": "Test"})]
+
+
+def test_win_toast_threaded(monkeypatch):
+    """Ensure win10toast uses threaded notifications on Windows."""
+    calls = {}
+
+    class FakeToast:
+        def show_toast(self, title, message, duration=5, threaded=False):
+            calls['threaded'] = threaded
+
+    monkeypatch.setattr(nh, 'sys', type('s', (), {'platform': 'win32'}))
+    monkeypatch.setitem(sys.modules, 'win10toast', type('m', (), {'ToastNotifier': lambda: FakeToast()}))
+    nh.run_tool({'title': 't', 'message': 'm'})
+    assert calls.get('threaded') is True
 

--- a/tests/test_windows_notifier.py
+++ b/tests/test_windows_notifier.py
@@ -1,0 +1,17 @@
+from tool_plugins import windows_notifier as wn
+import sys
+
+
+def test_windows_notifier_threaded(monkeypatch):
+    """Notification should use threaded=True to avoid blocking."""
+    calls = {}
+
+    class FakeToast:
+        def show_toast(self, title, message, duration=5, threaded=False):
+            calls['threaded'] = threaded
+            return True
+
+    monkeypatch.setitem(sys.modules, 'win10toast', type('m', (), {'ToastNotifier': lambda: FakeToast()}))
+    result = wn.run_tool({'title': 'T', 'message': 'M'})
+    assert result == "Notification sent"
+    assert calls.get('threaded') is True

--- a/tool_plugins/notification_hub.py
+++ b/tool_plugins/notification_hub.py
@@ -28,7 +28,8 @@ def _desktop_notify(title, message):
         try:
             from win10toast import ToastNotifier
             toaster = ToastNotifier()
-            toaster.show_toast(title, message, duration=5)
+            # Use threaded=True to avoid blocking or crashing the main thread
+            toaster.show_toast(title, message, duration=5, threaded=True)
             return True
         except Exception:
             return False

--- a/tool_plugins/windows_notifier.py
+++ b/tool_plugins/windows_notifier.py
@@ -15,7 +15,8 @@ def run_tool(args):
         return "[windows-notifier Error] win10toast not installed."
     try:
         toaster = ToastNotifier()
-        toaster.show_toast(title, message, duration=5)
+        # Run notification in a separate thread to prevent WNDPROC errors
+        toaster.show_toast(title, message, duration=5, threaded=True)
         return "Notification sent"
     except Exception as e:
         return f"[windows-notifier Error] {e}"


### PR DESCRIPTION
## Summary
- use threaded mode for Windows notifications
- ensure notification functions run in a separate thread
- add tests for threaded notification usage

## Testing
- `flake8 .` *(fails: E265, F401, E501, etc.)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424456c59883269f5c55e27a2d212f