### PR TITLE
Add progress indicators for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Tasks appear on a drag-and-drop calendar for easy rescheduling and completion.
     *   Filter tasks by agent or status using drop-down menus above the list.
     *   Each row contains Edit, Delete and Complete buttons for quick changes.
+    *   A progress bar shows how close each task is to its due time.
     *   Tasks can optionally repeat at a set interval.
     *   Due times must be in ISO 8601 format or `YYYY-MM-DD HH:MM:SS` local time.
         Today's date is highlighted and any date with tasks shows a small red dot.
@@ -253,7 +254,7 @@ script `run_task.py` so they execute even when Cerebro is not running.
 
 tasks.json
 This file stores the list of scheduled tasks. Each task entry includes an ``id``, ``creator``,
-``agent_name``, ``prompt``, ``due_time`` and ``status`` field. The status field defaults to ``pending``.
+``agent_name``, ``prompt``, ``due_time``, ``created_time`` and ``status`` field. The status field defaults to ``pending``.
 You typically won't edit this file directly.
 
 ## Testing

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -122,6 +122,7 @@ current day is highlighted. When there are no tasks a message labeled "No tasks 
 - **Toggle Status** – mark the selected task as completed or pending.
 - **Filters** – drop-down menus allow filtering by agent or status.
 - **Row Actions** – each task row includes Edit, Delete and Complete buttons.
+- **Progress Bar** – a bar in each row shows how close the task is to its due time.
 - **Repeat Interval** – optional number of minutes after which the task should repeat.
 - **Time Format** – enter times as ISO 8601 (YYYY-MM-DDTHH:MM:SS) or `YYYY-MM-DD HH:MM:SS` local time.
 
@@ -167,8 +168,8 @@ Contains tool metadata and Python code. Plugins placed in `tool_plugins` or inst
 `cerebro_tools` entry point are loaded automatically.
 
 ### tasks.json
-Holds scheduled tasks. Each entry has `id`, `creator`, `agent_name`, `prompt`, `due_time`, `status` and
-`repeat_interval` fields.
+Holds scheduled tasks. Each entry has `id`, `creator`, `agent_name`, `prompt`, `due_time`, `created_time`,
+`status` and `repeat_interval` fields.
 Tasks are also exported to the operating system scheduler using `run_task.py` so they can fire when Cerebro is closed.
 
 ### metrics.json

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QListWidgetItem,
     QLabel,
+    QProgressBar,
     QMessageBox,
     QDialog,
     QStyle,
@@ -25,6 +26,7 @@ from tasks import (
     delete_task,
     set_task_status,
     update_task_due_time,
+    compute_task_progress,
 )
 
 
@@ -230,6 +232,13 @@ class TasksTab(QWidget):
         summary = f"[{due_time}] {agent_name}{repeat_str} ({status}) - {prompt[:30]}..."
         label = QLabel(summary)
         layout.addWidget(label)
+
+        progress = compute_task_progress(task)
+        bar = QProgressBar()
+        bar.setRange(0, 100)
+        bar.setValue(progress)
+        bar.setFixedWidth(100)
+        layout.addWidget(bar)
 
         edit_btn = QPushButton("Edit")
         edit_btn.setProperty("task_id", task["id"])

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -1,5 +1,5 @@
 import os
-from PyQt5.QtWidgets import QApplication, QLabel, QPushButton
+from PyQt5.QtWidgets import QApplication, QLabel, QPushButton, QProgressBar
 import tab_tasks
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -47,4 +47,7 @@ def test_filters_and_row_actions():
     item_widget = tab.tasks_list.itemWidget(tab.tasks_list.item(0))
     buttons = item_widget.findChildren(QPushButton)
     assert len(buttons) == 3
+    bars = item_widget.findChildren(QProgressBar)
+    assert len(bars) == 1
+    assert 0 <= bars[0].value() <= 100
     app.quit()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import tasks
+from datetime import datetime
 
 
 def noop_save(tasks_, debug_enabled=False):
@@ -23,6 +24,7 @@ def test_add_task(monkeypatch):
     assert task["agent_name"] == "agent1"
     assert task["prompt"] == "do work"
     assert task["due_time"] == "2024-01-01 10:00"
+    assert "created_time" in task
     assert task["status"] == "pending"
     assert task["repeat_interval"] == 30
 
@@ -101,3 +103,13 @@ def test_update_task_due_time_missing(monkeypatch):
     monkeypatch.setattr(tasks, "save_tasks", noop_save)
     err = tasks.update_task_due_time(task_list, "missing", "2024-03-01 09:00")
     assert err == "[Task Error] Task 'missing' not found."
+
+
+def test_compute_task_progress():
+    task = {
+        "due_time": "2024-01-01 12:00:00",
+        "created_time": "2024-01-01 10:00:00",
+    }
+    now = datetime.strptime("2024-01-01 11:00:00", "%Y-%m-%d %H:%M:%S")
+    pct = tasks.compute_task_progress(task, now)
+    assert pct == 50


### PR DESCRIPTION
## Summary
- add `created_time` and `compute_task_progress` helper
- display task progress bars in Tasks tab
- document progress bar and new field in README and user guide
- test progress bar rendering and progress calculation

## Testing
- `flake8 .` *(fails: many existing style violations)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684231dced188326b8e5448a0dcfec2f