### PR TITLE
Add tray icon to Cerebro

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Customizable UI:**
     *   Light and dark mode support.
     *   Configurable user name, chat color and accent color.
+*   **System Tray Icon:**
+    *   Access quick actions from the tray to open the window, add a task or toggle dark mode.
 *   **Debug Mode:**
     *   Enables verbose logging for debugging purposes.
 *   **Metrics Dashboard:**

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -154,6 +154,14 @@ Global preferences are available under **Settings**.
 - The list of available models is cached so opening the dialog is fast.
 - Errors during updates are shown in a pop‑up message.
 
+## System Tray Icon
+
+When Cerebro is running a tray icon appears. Right-click it for quick actions:
+- **Open Cerebro** – restore the main window if it is hidden.
+- **Add Task** – open the task dialog without switching tabs.
+- **Toggle Dark Mode** – switch between light and dark themes.
+- **Quit** – exit the application entirely.
+
 ## Configuration Files
 
 Cerebro stores its data in several JSON files located in the application directory.

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from app import AIChatApp
 if __name__ == '__main__':
     print("[Debug] Starting AIChatApp...")
     app = QApplication(sys.argv)
+    app.setQuitOnLastWindowClosed(False)
     main_window = AIChatApp()
     main_window.show()
     sys.exit(app.exec_())

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -1,0 +1,14 @@
+import os
+from PyQt5.QtWidgets import QApplication
+from app import AIChatApp
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def test_tray_actions_exist():
+    app = QApplication.instance() or QApplication([])
+    window = AIChatApp()
+    actions = {a.text() for a in window.tray_icon.contextMenu().actions()}
+    assert {"Open Cerebro", "Add Task", "Toggle Dark Mode", "Quit"} <= actions
+    window.tray_icon.hide()
+    app.quit()


### PR DESCRIPTION
## Summary
- add system tray integration with quick actions
- persist app when window is closed
- document tray icon in README and user guide
- include regression test for tray actions

## Testing
- `flake8 . | head`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd81c4ac832682591f1dec4bdd1a