### PR TITLE
Add global screenshot interval setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
         keep prompts short.
 *   **Desktop History:**
     *   Agents with `desktop_history_enabled` enabled receive recent screenshots of your desktop.
-        Screens are captured at each agent's `screenshot_interval` and sent to the model as base64 images.
+        Screens are captured at the configured interval and sent to the model as base64 images.
+    *   The screenshot interval can be set globally in the **Settings** dialog.
 *   **Customizable UI:**
     *   Light and dark mode support.
     *   Configurable user name, chat color and accent color.

--- a/app.py
+++ b/app.py
@@ -73,6 +73,7 @@ class AIChatApp(QMainWindow):
         self.user_color = "#0000FF"
         self.accent_color = "#803391"
         self.dark_mode = False
+        self.screenshot_interval = 5
         self.screenshot_manager = ScreenshotManager()
         self.active_worker_threads = []
         
@@ -432,8 +433,12 @@ class AIChatApp(QMainWindow):
             self.user_color = settings_data["user_color"]
             self.accent_color = settings_data.get("accent_color", self.accent_color)
             self.debug_enabled = settings_data["debug_enabled"]
+            self.screenshot_interval = settings_data.get(
+                "screenshot_interval", self.screenshot_interval
+            )
             self.apply_updated_styles()
             self.agents_tab.update_model_dropdown()
+            self.update_screenshot_timer()
             self.save_settings()
             self.show_notification("Settings updated successfully")
 
@@ -1007,8 +1012,7 @@ class AIChatApp(QMainWindow):
             self.screenshot_manager.stop()
             return
 
-        interval = min(a.get("screenshot_interval", 5) for a in enabled_agents)
-        self.screenshot_manager.start(interval)
+        self.screenshot_manager.start(self.screenshot_interval)
 
     # -------------------------------------------------------------------------
     # Tools Management
@@ -1216,7 +1220,8 @@ class AIChatApp(QMainWindow):
             "user_name": self.user_name,
             "user_color": self.user_color,
             "accent_color": self.accent_color,
-            "dark_mode": self.dark_mode
+            "dark_mode": self.dark_mode,
+            "screenshot_interval": self.screenshot_interval,
         }
         try:
             with open(SETTINGS_FILE, "w") as f:
@@ -1239,6 +1244,9 @@ class AIChatApp(QMainWindow):
                 self.user_color = settings.get("user_color", "#0000FF")
                 self.accent_color = settings.get("accent_color", "#803391")
                 self.dark_mode = settings.get("dark_mode", False)
+                self.screenshot_interval = settings.get(
+                    "screenshot_interval", self.screenshot_interval
+                )
                 if self.debug_enabled:
                     print("[Debug] Settings loaded.")
             except Exception as e:

--- a/dialogs.py
+++ b/dialogs.py
@@ -266,6 +266,16 @@ class SettingsDialog(QDialog):
         self.debug_enabled_checkbox.setToolTip("Enable or disable debug mode.")
         layout.addWidget(self.debug_enabled_checkbox)
 
+        # Screenshot Interval
+        layout.addWidget(QLabel("Screenshot Interval (s):"))
+        self.interval_spin = QSpinBox()
+        self.interval_spin.setRange(1, 60)
+        self.interval_spin.setValue(self.parent.screenshot_interval)
+        self.interval_spin.setToolTip(
+            "Seconds between screenshots when desktop history is enabled."
+        )
+        layout.addWidget(self.interval_spin)
+
         # --- Ollama Updates ---
         update_label = QLabel("Update Ollama and Models:")
         layout.addWidget(update_label)
@@ -317,7 +327,8 @@ class SettingsDialog(QDialog):
             "user_name": self.user_name_edit.text().strip(),
             "user_color": self.parent.user_color,  # Color is already updated
             "accent_color": self.parent.accent_color,
-            "debug_enabled": self.debug_enabled_checkbox.isChecked()
+            "debug_enabled": self.debug_enabled_checkbox.isChecked(),
+            "screenshot_interval": self.interval_spin.value(),
         }
 
     def update_ollama(self):

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -150,6 +150,7 @@ Displays this guide within the application so you can review instructions withou
 
 Global preferences are available under **Settings**.
 - Toggle dark mode and change your displayed user name, chat color and accent color.
+- Choose how often desktop screenshots are captured when history is enabled.
 - Update the Ollama runtime or pull the latest version of a model using the provided buttons.
 - The list of available models is cached so opening the dialog is fast.
 - Errors during updates are shown in a pop‑up message.

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,0 +1,69 @@
+import os
+from PyQt5.QtWidgets import QApplication, QWidget
+import dialogs
+import app
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyAgentsTab:
+    def __init__(self):
+        self.global_agent_preferences = {"available_models": []}
+    def load_global_preferences(self):
+        pass
+    def update_model_dropdown(self):
+        pass
+
+class DummyManager:
+    def __init__(self):
+        self.started = None
+        self.stopped = False
+    def start(self, interval):
+        self.started = interval
+    def stop(self):
+        self.stopped = True
+
+class DummyAppBase:
+    def __init__(self):
+        self.dark_mode = False
+        self.user_name = "You"
+        self.user_color = "#0000FF"
+        self.accent_color = "#803391"
+        self.debug_enabled = False
+        self.screenshot_interval = 5
+        self.agents_tab = DummyAgentsTab()
+        self.screenshot_manager = DummyManager()
+        self.agents_data = {"a": {"desktop_history_enabled": True}}
+    def apply_updated_styles(self):
+        pass
+    def save_settings(self):
+        pass
+    def show_notification(self, *a, **k):
+        pass
+
+
+class DummyApp(DummyAppBase, QWidget):
+    def __init__(self):
+        QWidget.__init__(self)
+        DummyAppBase.__init__(self)
+
+
+def test_settings_dialog_returns_interval():
+    app_instance = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    dlg = dialogs.SettingsDialog(dummy)
+    dlg.interval_spin.setValue(8)
+    data = dlg.get_data()
+    assert data["screenshot_interval"] == 8
+    app_instance.quit()
+
+def test_update_screenshot_timer_uses_global(monkeypatch):
+    dummy = DummyAppBase()
+    dummy.screenshot_interval = 7
+    app.AIChatApp.update_screenshot_timer(dummy)
+    assert dummy.screenshot_manager.started == 7
+
+    dummy.agents_data = {}
+    dummy.screenshot_manager = DummyManager()
+    app.AIChatApp.update_screenshot_timer(dummy)
+    assert dummy.screenshot_manager.stopped
+


### PR DESCRIPTION
## Summary
- allow global screenshot interval in `SettingsDialog`
- store screenshot interval in settings and update timer accordingly
- document new setting
- test new behavior

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd9da62c83269306268279c4ef66