### PR TITLE
Fix workflow tab

### DIFF
--- a/tab_workflows.py
+++ b/tab_workflows.py
@@ -135,7 +135,8 @@ class WorkflowsTab(QWidget):
             if not data["name"]:
                 QMessageBox.warning(self, "Invalid", "Name is required")
                 return
-            wf_id = workflows.add_workflow(self.workflows, **data)
+            wf_type = data.pop("type")
+            wf_id = workflows.add_workflow(self.workflows, wf_type=wf_type, **data)
             self.parent_app.workflows = self.workflows
             self.refresh_list()
 


### PR DESCRIPTION
## Summary
- fix wrong argument name when adding workflows

## Testing
- `flake8 .` *(fails: various style issues)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684374287c1c83268c17c197ff99be49