### PR TITLE
Add default agent using first Ollama model

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ This file stores the configuration for each agent.
 *   **`tool_use`:** Boolean value to enable or disable an agent's access to tools.
 *   **`tools_enabled`:** A list of tools that an agent can access, assuming `tool_use` is set to true.
 *   The bundled `Default Agent` comes enabled with all built-in tools for general use.
+*   On first launch, the app selects the first model returned by `ollama list` for this agent.
 
 **Example:**
 

--- a/agents.json
+++ b/agents.json
@@ -1,9 +1,9 @@
 {
   "Default Agent": {
     "model": "llama3.2-vision",
-    "temperature": 0.7999999999999999,
+    "temperature": 0.7,
     "max_tokens": 512,
-    "system_prompt": "You are a helpful assistant with full tool access. If a tool will help, reply with the tool JSON described in the docs. Otherwise, answer succinctly in plain text.",
+    "system_prompt": "You are the Cerebro default assistant with full tool access. Use tools whenever they help and keep replies concise.",
     "enabled": true,
     "description": "A general purpose assistant agent.  Responds directly to the user like a chatbot.",
     "role": "Assistant",

--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from tool_utils import (
     format_tool_result_html,
     format_tool_block_html,
 )
+from local_llm_helper import get_installed_models
 import tts
 
 AGENTS_SAVE_FILE = "agents.json"
@@ -967,24 +968,29 @@ class AIChatApp(QMainWindow):
             except Exception as e:
                 print(f"[Debug] Failed to load agents: {e}")
         else:
+            models = get_installed_models()
+            model = models[0] if models else "llama3.2-vision"
             default_agent_settings = {
-                "model": "llama3.2-vision",
+                "model": model,
                 "temperature": 0.7,
                 "max_tokens": 512,
-                "system_prompt": "",
+                "system_prompt": (
+                    "You are the Cerebro default assistant with full tool access. "
+                    "Use tools whenever they help and keep replies concise."
+                ),
                 "enabled": True,
                 "color": "#000000",
                 "include_image": False,
                 "desktop_history_enabled": False,
                 "screenshot_interval": 5,
                 "role": "Assistant",  # Default role
-                "description": "A general-purpose assistant.", # Default description
-                "tool_use": False,
-                "tools_enabled": [],
+                "description": "A general-purpose assistant.",
+                "tool_use": True,
+                "tools_enabled": [t["name"] for t in self.tools],
                 "automations_enabled": [],
                 "thinking_enabled": False,
                 "thinking_steps": 3,
-                "tts_enabled": False
+                "tts_enabled": False,
             }
             self.agents_data["Default Agent"] = default_agent_settings
             if self.debug_enabled:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 Cerebro stores data in several JSON files in the application directory.
 
 ## agents.json
-Defines every agent and their settings. The default configuration includes a **Default Agent** with all bundled tools enabled.
+Defines every agent and their settings. The default configuration includes a **Default Agent** with all bundled tools enabled. If no agent configuration exists, its model is set to the first entry from `ollama list` when available.
 
 ## tools.json
 Metadata and Python code for tools. Plugins placed in `tool_plugins` or installed via the `cerebro_tools` entry point are loaded automatically.

--- a/local_llm_helper.py
+++ b/local_llm_helper.py
@@ -44,6 +44,24 @@ def start_server() -> None:
     subprocess.run(["ollama", "serve"], check=True)
 
 
+def get_installed_models() -> list[str]:
+    """Return a list of installed Ollama models."""
+    try:
+        result = subprocess.run(
+            ["ollama", "list"], capture_output=True, text=True, check=True
+        )
+    except Exception:
+        return []
+
+    models = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        models.append(line.split()[0])
+    return models
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Local LLM deployment helper")
     sub = parser.add_subparsers(dest="cmd", required=True)

--- a/tests/test_local_llm_helper.py
+++ b/tests/test_local_llm_helper.py
@@ -6,3 +6,14 @@ def test_check_ollama_installed(monkeypatch):
     assert llh.check_ollama_installed() is True
     monkeypatch.setattr(llh.shutil, "which", lambda cmd: None)
     assert llh.check_ollama_installed() is False
+
+
+def test_get_installed_models(monkeypatch):
+    class Result:
+        stdout = "model1\nmodel2\n"
+
+    def fake_run(*args, **kwargs):
+        return Result()
+
+    monkeypatch.setattr(llh.subprocess, "run", fake_run)
+    assert llh.get_installed_models() == ["model1", "model2"]


### PR DESCRIPTION
## Summary
- add helper to list installed Ollama models
- pick first installed model when creating default agent
- enable tool use and system prompt in default agent config
- document new default model behaviour
- test listing installed models

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684376e77fa883268172827d99a2cb6c