### PR TITLE
Improve automation replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   The Tool script editor features Python syntax highlighting when QScintilla is installed.
     *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models. Model names are cached so the dialog opens quickly.
 
-*   **Automations Tab:** Record desktop actions and replay them later.
+*   **Automations Tab:** Record desktop actions and replay them later. Playback
+    jumps directly to click and drag positions for quicker execution.
 
 *   **Task Scheduling:**
     *   Agents can schedule tasks to be executed at a specific time. New tasks default to one minute from the current time.

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -61,7 +61,8 @@ Tools are triggered when an agent returns a JSON block in the format produced by
 
 Record and play back desktop actions.
 - **Record** – capture mouse and keyboard events for a duration.
-- **Run** – replay the selected sequence using `pyautogui`.
+- **Run** – replay the selected sequence using `pyautogui`. Mouse moves are
+  skipped so the cursor jumps to each click or drag location.
 - **Delete** – remove a saved automation.
 
 ## Tasks Tab


### PR DESCRIPTION
## Summary
- speed up playback by skipping mouse movement events
- describe updated behavior in docs
- expand automation tests for click jumping

## Testing
- `flake8 automation_sequences.py tests/test_automation_sequences.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437699862c8326abdbca7579da1440