### PR TITLE
Add step configuration dialog for user-managed workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Workflow Builder:**
     *   Create reusable workflows that coordinate multiple agents.
     *   Supports **Agent Managed** and **User Managed** modes.
+    *   In **User Managed** mode, set the number of steps then select an agent
+        and prompt for each step.
     *   Workflows are edited on a dedicated tab with drag-and-drop ordering.
 *   **Chat History Management:**
     *   Each session begins with a blank conversation.

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -84,7 +84,8 @@ When a task becomes due the prompt is sent automatically. Tasks can also be regi
 
 Design multi-agent workflows that can be executed repeatedly.
 - **Agent Managed** – a coordinator assigns subtasks to other agents.
-- **User Managed** – define the exact sequence of agents, models and prompts.
+- **User Managed** – specify the number of steps and for each step choose an agent
+  and an additional prompt to send alongside the chat history.
 
 ## Metrics Tab
 


### PR DESCRIPTION
## Summary
- allow configuration of individual steps in user managed workflows
- document new workflow step behaviour

## Testing
- `flake8 . | head -n 20`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684395399910832698c56e7cd386e4dc