### PR TITLE
Add check box list for managed workflow agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   The included **Windows Notifier** tool can display Windows 11 notifications when a scheduled task runs.
 *   **Workflow Builder:**
     *   Create reusable workflows that coordinate multiple agents.
-    *   Supports **Agent Managed** and **User Managed** modes.
-    *   In **User Managed** mode, set the number of steps then select an agent
+*   Supports **Agent Managed** and **User Managed** modes.
+*   In **Agent Managed** mode, pick multiple agents from a check box list.
+*   In **User Managed** mode, set the number of steps then select an agent
         and prompt for each step.
     *   Workflows are edited on a dedicated tab with drag-and-drop ordering.
 *   **Chat History Management:**

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -84,7 +84,8 @@ When a task becomes due the prompt is sent automatically. Tasks can also be regi
 ## Workflows Tab
 
 Design multi-agent workflows that can be executed repeatedly.
-- **Agent Managed** – a coordinator assigns subtasks to other agents.
+- **Agent Managed** – a coordinator assigns subtasks to other agents. Select
+  multiple agents using the check box list.
 - **User Managed** – specify the number of steps and for each step choose an agent
   and an additional prompt to send alongside the chat history.
 

--- a/tests/test_workflow_dialog.py
+++ b/tests/test_workflow_dialog.py
@@ -1,0 +1,17 @@
+import os
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import Qt
+import tab_workflows
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+def test_selected_agents():
+    app = QApplication.instance() or QApplication([])
+    dlg = tab_workflows.WorkflowDialog(["a1", "a2", "a3"])
+    for i in range(dlg.agent_list.count()):
+        item = dlg.agent_list.item(i)
+        if item.text() in {"a1", "a3"}:
+            item.setCheckState(Qt.Checked)
+    data = dlg.get_data()
+    assert set(data["agents"]) == {"a1", "a3"}
+    app.quit()


### PR DESCRIPTION
## Summary
- show all agents as check boxes in the workflow dialog
- note new selection behavior in README and docs
- cover workflow dialog agent selection with a test

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c6eeac94832686cd52aee16f2fe3