### PR TITLE
Add workflow runner execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   In **User Managed** mode, set the number of steps then select an agent
         and prompt for each step.
     *   Workflows are edited on a dedicated tab with drag-and-drop ordering.
+    *   Click **Run** on the Workflows tab to test a workflow with a custom prompt.
+    *   Workflows can also be invoked from chat using `/run workflow <name> [prompt]`.
 *   **Chat History Management:**
     *   Each session begins with a blank conversation.
     *   History can be saved, exported or cleared from the chat menu if desired.

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -88,6 +88,8 @@ Design multi-agent workflows that can be executed repeatedly.
   multiple agents using the check box list.
 - **User Managed** – specify the number of steps and for each step choose an agent
   and an additional prompt to send alongside the chat history.
+Run a workflow manually using the **Run** button and provide a starting prompt.
+Workflows may also be started from chat with `/run workflow <name> [prompt]`.
 
 ## Metrics Tab
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -34,3 +34,37 @@ def test_delete_workflow(monkeypatch):
     err = workflows.delete_workflow(wf_list, wf_id)
     assert err is None
     assert wf_list == []
+
+
+def test_find_workflow_by_name(monkeypatch):
+    wf_list = []
+    monkeypatch.setattr(workflows, "save_workflows", noop_save)
+    wf_id = workflows.add_workflow(wf_list, "demo", "user_managed")
+    wf = workflows.find_workflow_by_name(wf_list, "demo")
+    assert wf and wf["id"] == wf_id
+    assert workflows.find_workflow_by_name(wf_list, "missing") is None
+
+
+def test_execute_workflow_user():
+    wf = {
+        "id": "1",
+        "name": "demo",
+        "type": "user_managed",
+        "steps": [{"agent": "a1", "prompt": "p"}],
+    }
+    log, result = workflows.execute_workflow(wf, "start")
+    assert log and log[0].startswith("[a1]")
+    assert result
+
+
+def test_execute_workflow_agent():
+    wf = {
+        "id": "1",
+        "name": "demo",
+        "type": "agent_managed",
+        "coordinator": "c1",
+        "agents": ["a1", "a2"],
+    }
+    log, result = workflows.execute_workflow(wf, "start")
+    assert any("c1" in line for line in log)
+    assert result == "Workflow completed"


### PR DESCRIPTION
## Summary
- create workflow execution helpers
- allow workflows to be run from Workflows tab
- add `/run workflow` chat command
- show workflow activity in a runner dialog
- document new workflow features
- test workflow execution helpers

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c8de4a3483269dc2fd0f7b7c14c9