### PR TITLE
Switch to dark mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
         Screens are captured at the configured interval and sent to the model as base64 images.
     *   The screenshot interval can be set globally in the **Settings** dialog.
 *   **Customizable UI:**
-    *   Light and dark mode support.
+    *   Light and dark mode support. Dark mode is enabled by default.
     *   Configurable user name, chat color and accent color.
 *   **System Tray Icon:**
     *   Access quick actions from the tray to open the window, add a task or toggle dark mode.
@@ -231,7 +231,7 @@ image_path: Currently unused.
 user_name: The user's display name.
 user_color: The user's chat message color.
 accent_color: The primary UI accent color used in the application theme.
-dark_mode: Enables dark mode (boolean).
+dark_mode: Enables dark mode (boolean, default true).
 tools.json
 This file defines available tools.
 

--- a/app.py
+++ b/app.py
@@ -77,7 +77,7 @@ class AIChatApp(QMainWindow):
         self.user_name = "You"
         self.user_color = "#0000FF"
         self.accent_color = "#803391"
-        self.dark_mode = False
+        self.dark_mode = True
         self.screenshot_interval = 5
         self.screenshot_manager = ScreenshotManager()
         self.active_worker_threads = []

--- a/light_mode.qss
+++ b/light_mode.qss
@@ -18,19 +18,19 @@ QMainWindow {
 }
 
 #logoContainer {
-    background-color: {ACCENT_COLOR};
-    border-bottom: 1px solid #e0e0e0;
+    background-color: #ffffff;
+    border-bottom: 2px solid {ACCENT_COLOR};
 }
 
 #appLogo {
     font-size: 24px;
     font-weight: bold;
-    color: #ffffff;
+    color: {ACCENT_COLOR};
 }
 
 #appTagline {
     font-size: 13px;
-    color: #ffffff; /* Brighter white for better contrast */
+    color: #333333;
     font-weight: 500;
 }
 


### PR DESCRIPTION
## Summary
- default to dark mode when launching the app
- clarify dark mode defaults in documentation
- adjust light theme for better logo and tagline visibility

## Testing
- `flake8 .` *(fails: numerous style violations)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ca86e1108326ac430eba47a83b46