### PR TITLE
Fix tray quit action

### DIFF
--- a/app.py
+++ b/app.py
@@ -360,7 +360,9 @@ class AIChatApp(QMainWindow):
     def quit_from_tray(self):
         """Quit the application from the tray icon."""
         self.force_quit = True
-        self.close()
+        if getattr(self, "tray_icon", None):
+            self.tray_icon.hide()
+        QApplication.quit()
             
     def show_help_dialog(self):
         """Show the help dialog."""

--- a/tests/test_quit_action.py
+++ b/tests/test_quit_action.py
@@ -1,0 +1,20 @@
+import os
+from PyQt5.QtWidgets import QApplication
+from app import AIChatApp
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def test_quit_from_tray(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    window = AIChatApp()
+    called = {"flag": False}
+
+    def fake_quit():
+        called["flag"] = True
+
+    monkeypatch.setattr(QApplication, "quit", staticmethod(fake_quit))
+    window.quit_from_tray()
+    assert called["flag"]
+    assert window.force_quit
+    app.quit()


### PR DESCRIPTION
## Summary
- ensure the tray Quit option exits Cerebro
- test quitting from tray

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d5a8066483268876f2a9c4adcfa0