### PR TITLE
Enhance debug logging

### DIFF
--- a/message_broker.py
+++ b/message_broker.py
@@ -39,6 +39,9 @@ class MessageBroker:
             message (str): The message content.
         """
         timestamp = datetime.now().strftime("%H:%M:%S")
+        if self.app and self.app.debug_enabled:
+            target = recipient or "broadcast"
+            print(f"[Debug] send_message from '{sender}' to '{target}': {message}")
 
         if sender == "user":
             user_message_html = f'<span style="color:{self.app.user_color};">[{timestamp}] {self.app.user_name}:</span> {message}'
@@ -108,6 +111,8 @@ class MessageBroker:
             message (str): The message content.
         """
         timestamp = datetime.now().strftime("%H:%M:%S")
+        if self.app and self.app.debug_enabled:
+            print(f"[Debug] Routing message from '{sender}' to '{recipient}'")
         agent_settings = self.app.agents_data.get(recipient) if self.app else None
 
         if not agent_settings:
@@ -156,6 +161,11 @@ class MessageBroker:
         worker.finished.connect(on_finished)
 
         thread.started.connect(worker.run)
+        if self.app and self.app.debug_enabled:
+            print(
+                f"[Debug] Starting worker for '{recipient}' using model '{model_name}'"
+                f" (temp={temperature}, max_tokens={max_tokens})"
+            )
         thread.start()
 
     def worker_finished_sequential(self, sender_worker, thread, agent_name):
@@ -437,6 +447,8 @@ class MessageBroker:
             message (str): The message content.
         """
         timestamp = datetime.now().strftime("%H:%M:%S")
+        if self.app and self.app.debug_enabled:
+            print(f"[Debug] send_message_to_agent '{agent_name}': {message}")
 
         # Check if the agent exists and is enabled
         agent_settings = self.app.agents_data.get(agent_name, {})
@@ -495,6 +507,11 @@ class MessageBroker:
             agent_name,
             self.app.agents_data
         )
+        if self.app.debug_enabled:
+            print(
+                f"[Debug] Starting worker for '{agent_name}' using model '{model_name}'"
+                f" (temp={temperature}, max_tokens={max_tokens})"
+            )
         worker.moveToThread(thread)
         self.active_worker_threads.append((worker, thread))
 

--- a/tasks.py
+++ b/tasks.py
@@ -158,6 +158,11 @@ def add_task(
     }
     tasks.append(new_task)
     save_tasks(tasks, debug_enabled)
+    if debug_enabled:
+        print(
+            f"[Debug] Added task {task_id} for agent '{agent_name}'"
+            f" due {due_time} (repeat every {repeat_interval} min)"
+        )
     if os_schedule:
         _schedule_os_task(task_id, due_time, debug_enabled)
     return task_id
@@ -181,6 +186,10 @@ def edit_task(
     task["due_time"] = due_time
     task["repeat_interval"] = repeat_interval
     save_tasks(tasks, debug_enabled)
+    if debug_enabled:
+        print(
+            f"[Debug] Edited task {task_id}: agent='{agent_name}', due {due_time}, repeat {repeat_interval}"
+        )
     if os_schedule:
         _remove_os_task(task_id, debug_enabled)
         _schedule_os_task(task_id, due_time, debug_enabled)
@@ -192,6 +201,8 @@ def delete_task(tasks, task_id, debug_enabled=False, os_schedule=False):
         return f"[Task Error] Task '{task_id}' not found."
     del tasks[idx]
     save_tasks(tasks, debug_enabled)
+    if debug_enabled:
+        print(f"[Debug] Deleted task {task_id}")
     if os_schedule:
         _remove_os_task(task_id, debug_enabled)
     return None
@@ -203,6 +214,8 @@ def set_task_status(tasks, task_id, status, debug_enabled=False):
         return f"[Task Error] Task '{task_id}' not found."
     task["status"] = status
     save_tasks(tasks, debug_enabled)
+    if debug_enabled:
+        print(f"[Debug] Set task {task_id} status to '{status}'")
     return None
 
 def update_task_due_time(tasks, task_id, due_time, debug_enabled=False, os_schedule=False):
@@ -212,6 +225,8 @@ def update_task_due_time(tasks, task_id, due_time, debug_enabled=False, os_sched
         return f"[Task Error] Task '{task_id}' not found."
     task["due_time"] = due_time
     save_tasks(tasks, debug_enabled)
+    if debug_enabled:
+        print(f"[Debug] Updated task {task_id} due time to {due_time}")
     if os_schedule:
         _remove_os_task(task_id, debug_enabled)
         _schedule_os_task(task_id, due_time, debug_enabled)


### PR DESCRIPTION
## Summary
- add verbose debug logging for task operations
- print routing and worker start details when debug mode is enabled

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d5e516f4832691e401317c0dd36b