### PR TITLE
Add configurable chat summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ user_name: The user's display name.
 user_color: The user's chat message color.
 accent_color: The primary UI accent color used in the application theme.
 dark_mode: Enables dark mode (boolean, default true).
+summarization_threshold: Number of recent messages to keep before summarizing.
+    Set to 0 to disable summarization.
 tools.json
 This file defines available tools.
 

--- a/app.py
+++ b/app.py
@@ -84,6 +84,7 @@ class AIChatApp(QMainWindow):
         self.accent_color = "#803391"
         self.dark_mode = True
         self.screenshot_interval = 5
+        self.summarization_threshold = 20
         self.screenshot_manager = ScreenshotManager()
         self.active_worker_threads = []
         
@@ -497,6 +498,9 @@ class AIChatApp(QMainWindow):
             self.debug_enabled = settings_data["debug_enabled"]
             self.screenshot_interval = settings_data.get(
                 "screenshot_interval", self.screenshot_interval
+            )
+            self.summarization_threshold = settings_data.get(
+                "summarization_threshold", self.summarization_threshold
             )
             self.apply_updated_styles()
             self.agents_tab.update_model_dropdown()
@@ -1226,7 +1230,9 @@ class AIChatApp(QMainWindow):
     def build_agent_chat_history(self, agent_name, user_message=None, is_screenshot=False):
         # Reload history from disk to ensure persistence
         self.chat_history = load_history(self.debug_enabled)
-        self.chat_history = summarize_history(self.chat_history)
+        self.chat_history = summarize_history(
+            self.chat_history, threshold=self.summarization_threshold
+        )
 
         system_prompt = ""
         agent_settings = self.agents_data.get(agent_name, {})
@@ -1324,6 +1330,7 @@ class AIChatApp(QMainWindow):
             "accent_color": self.accent_color,
             "dark_mode": self.dark_mode,
             "screenshot_interval": self.screenshot_interval,
+            "summarization_threshold": self.summarization_threshold,
         }
         try:
             with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
@@ -1348,6 +1355,9 @@ class AIChatApp(QMainWindow):
                 self.dark_mode = settings.get("dark_mode", False)
                 self.screenshot_interval = settings.get(
                     "screenshot_interval", self.screenshot_interval
+                )
+                self.summarization_threshold = settings.get(
+                    "summarization_threshold", self.summarization_threshold
                 )
                 if self.debug_enabled:
                     print("[Debug] Settings loaded.")

--- a/dialogs.py
+++ b/dialogs.py
@@ -276,6 +276,17 @@ class SettingsDialog(QDialog):
         )
         layout.addWidget(self.interval_spin)
 
+        # Summarization Threshold
+        layout.addWidget(QLabel("Summarization Threshold:"))
+        self.threshold_spin = QSpinBox()
+        self.threshold_spin.setRange(0, 200)
+        self.threshold_spin.setValue(self.parent.summarization_threshold)
+        self.threshold_spin.setToolTip(
+            "Number of recent messages to keep before summarizing."
+            " Set to 0 to disable summarization."
+        )
+        layout.addWidget(self.threshold_spin)
+
         # --- Ollama Updates ---
         update_label = QLabel("Update Ollama and Models:")
         layout.addWidget(update_label)
@@ -329,6 +340,7 @@ class SettingsDialog(QDialog):
             "accent_color": self.parent.accent_color,
             "debug_enabled": self.debug_enabled_checkbox.isChecked(),
             "screenshot_interval": self.interval_spin.value(),
+            "summarization_threshold": self.threshold_spin.value(),
         }
 
     def update_ollama(self):

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -10,6 +10,7 @@ The Chat tab is the main interface for sending prompts to your agents.
 - Use the menu to copy, save, export or clear the conversation.
 - Click the 🔍 button to search the current conversation.
 - Long conversations are automatically summarized to keep prompts short.
+  You can adjust or disable this threshold in the **Settings** dialog.
 - Agents with *desktop history* enabled attach periodic screenshots for visual context.
 
 ## Agents Tab

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,11 @@ Records tool usage counts, task completions and average response times.
 ## chat_history.json
 Stores conversation history for exporting or resuming later. The file is recreated each time the application starts unless you export the history.
 
+## settings.json
+Stores global preferences such as theme, screenshot interval and
+``summarization_threshold``. Set the threshold to 0 to disable automatic
+summaries.
+
 ## Debug Mode
 
 Set `DEBUG_MODE=1` before launching to enable verbose console logging. This helps diagnose issues with tools or agent configuration.

--- a/message_broker.py
+++ b/message_broker.py
@@ -357,8 +357,11 @@ class MessageBroker:
         Returns:
             list: The chat history for the agent.
         """
-        self.chat_history = load_history(self.app.debug_enabled if self.app else False)
-        self.chat_history = summarize_history(self.chat_history)
+        self.chat_history = load_history(
+            self.app.debug_enabled if self.app else False
+        )
+        threshold = getattr(self.app, "summarization_threshold", 20)
+        self.chat_history = summarize_history(self.chat_history, threshold=threshold)
         system_prompt = ""
         agent_settings = self.app.agents_data.get(agent_name, {}) if self.app else {}
 

--- a/tests/test_message_broker.py
+++ b/tests/test_message_broker.py
@@ -23,7 +23,11 @@ def test_build_agent_chat_history(monkeypatch):
         {'role': 'assistant', 'content': 'A', 'agent': 'agent1'}
     ]
     monkeypatch.setattr(message_broker, 'load_history', lambda debug=False: history)
-    monkeypatch.setattr(message_broker, 'summarize_history', lambda h: h)
+    monkeypatch.setattr(
+        message_broker,
+        'summarize_history',
+        lambda h, threshold=20: h
+    )
     monkeypatch.setattr(message_broker, 'generate_tool_instructions_message', lambda app, name: 'tools')
     monkeypatch.setattr(tts, 'speak_text', lambda *a, **k: None)
     broker = message_broker.MessageBroker(app)

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -30,6 +30,7 @@ class DummyAppBase:
         self.accent_color = "#803391"
         self.debug_enabled = False
         self.screenshot_interval = 5
+        self.summarization_threshold = 20
         self.agents_tab = DummyAgentsTab()
         self.screenshot_manager = DummyManager()
         self.agents_data = {"a": {"desktop_history_enabled": True}}
@@ -52,8 +53,10 @@ def test_settings_dialog_returns_interval():
     dummy = DummyApp()
     dlg = dialogs.SettingsDialog(dummy)
     dlg.interval_spin.setValue(8)
+    dlg.threshold_spin.setValue(30)
     data = dlg.get_data()
     assert data["screenshot_interval"] == 8
+    assert data["summarization_threshold"] == 30
     app_instance.quit()
 
 def test_update_screenshot_timer_uses_global(monkeypatch):

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -24,3 +24,13 @@ def test_summarize_history():
     summarized = transcripts.summarize_history(history, threshold=10)
     assert summarized[0]["role"] == "system"
     assert len(summarized) == 11
+
+
+def test_summarize_history_disabled():
+    history = []
+    for i in range(5):
+        role = "user" if i % 2 == 0 else "assistant"
+        history.append({"role": role, "content": f"msg{i}", "agent": "a"})
+
+    summarized = transcripts.summarize_history(history, threshold=0)
+    assert summarized == history

--- a/transcripts.py
+++ b/transcripts.py
@@ -81,6 +81,9 @@ def summarize_history(history, threshold=20, max_chars=1000):
     Returns:
         list: Summarized chat history.
     """
+    if threshold is None or threshold <= 0:
+        return history[:]
+
     if len(history) <= threshold:
         return history[:]
 


### PR DESCRIPTION
## Summary
- allow disabling or adjusting chat summarization
- store `summarization_threshold` in `settings.json`
- expose threshold in Settings dialog
- pass threshold through chat history builders
- document the new option
- test summarization disablement and settings dialog support

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d77ba118832699e3384e3ca69c80