### PR TITLE
Add expanded system tray actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Light and dark mode support. Dark mode is enabled by default.
     *   Configurable user name, chat color and accent color.
 *   **System Tray Icon:**
-    *   Access quick actions from the tray to open the window, add a task or toggle dark mode.
+    *   Access quick actions from the tray to open the window, add a task, toggle dark mode, pause notifications or start/stop screenshot capture.
 *   **Debug Mode:**
     *   Enables verbose logging for debugging purposes.
 *   **Metrics Dashboard:**

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -32,6 +32,7 @@ class DummyAppBase:
         self.screenshot_interval = 5
         self.agents_tab = DummyAgentsTab()
         self.screenshot_manager = DummyManager()
+        self.screenshot_paused = False
         self.agents_data = {"a": {"desktop_history_enabled": True}}
     def apply_updated_styles(self):
         pass
@@ -62,6 +63,12 @@ def test_update_screenshot_timer_uses_global(monkeypatch):
     app.AIChatApp.update_screenshot_timer(dummy)
     assert dummy.screenshot_manager.started == 7
 
+    dummy.screenshot_paused = True
+    dummy.screenshot_manager = DummyManager()
+    app.AIChatApp.update_screenshot_timer(dummy)
+    assert dummy.screenshot_manager.stopped
+
+    dummy.screenshot_paused = False
     dummy.agents_data = {}
     dummy.screenshot_manager = DummyManager()
     app.AIChatApp.update_screenshot_timer(dummy)

--- a/tests/test_system_tray.py
+++ b/tests/test_system_tray.py
@@ -9,6 +9,14 @@ def test_tray_actions_exist():
     app = QApplication.instance() or QApplication([])
     window = AIChatApp()
     actions = {a.text() for a in window.tray_icon.contextMenu().actions()}
-    assert {"Open Cerebro", "Add Task", "Toggle Dark Mode", "Quit"} <= actions
+    expected = {
+        "Open Cerebro",
+        "Add Task",
+        "Toggle Dark Mode",
+        "Pause Notifications",
+        "Start Screenshot Capture",
+        "Quit",
+    }
+    assert expected <= actions
     window.tray_icon.hide()
     app.quit()


### PR DESCRIPTION
## Summary
- add pause/resume controls for notifications
- allow starting or stopping screenshot capture
- expose new actions in tray menu
- document updated tray options
- test screenshot pause logic and tray actions

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d7a4d2ac83269f9657c97a482fc1