### PR TITLE
Add plugins tab for managing tool plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
     *   Includes a **Credential Manager** plugin for securely storing API keys using the system keyring.
     *   Includes an **Automated Update Manager** plugin for checking for new versions and downloading updates on Windows 11.
     *   Bundles a **Task Sequence Recorder** plugin to capture mouse and keyboard actions and replay them later.
+    *   Manage plugins using the **Plugins** tab to install, enable or disable them.
     *   Tools can be updated using the **Edit Tool** button in the Tools tab.
     *   The Tool script editor features Python syntax highlighting when QScintilla is installed.
     *   The Settings dialog provides buttons to update the Ollama runtime and refresh individual models. Model names are cached so the dialog opens quickly.

--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from transcripts import (
 from tab_chat import ChatTab
 from tab_agents import AgentsTab
 from tab_tools import ToolsTab
+from tab_plugins import PluginsTab
 from tab_automations import AutomationsTab
 from tab_tasks import TasksTab
 from tab_metrics import MetricsTab
@@ -151,24 +152,28 @@ class AIChatApp(QMainWindow):
         self.nav_buttons["tools"] = self.create_nav_button("Tools", 2)
         sidebar_layout.addWidget(self.nav_buttons["tools"])
 
+        # Plugins button
+        self.nav_buttons["plugins"] = self.create_nav_button("Plugins", 3)
+        sidebar_layout.addWidget(self.nav_buttons["plugins"])
+
         # Automations button
-        self.nav_buttons["automations"] = self.create_nav_button("Automations", 3)
+        self.nav_buttons["automations"] = self.create_nav_button("Automations", 4)
         sidebar_layout.addWidget(self.nav_buttons["automations"])
 
         # Tasks button
-        self.nav_buttons["tasks"] = self.create_nav_button("Tasks", 4)
+        self.nav_buttons["tasks"] = self.create_nav_button("Tasks", 5)
         sidebar_layout.addWidget(self.nav_buttons["tasks"])
 
         # Workflows button
-        self.nav_buttons["workflows"] = self.create_nav_button("Workflows", 5)
+        self.nav_buttons["workflows"] = self.create_nav_button("Workflows", 6)
         sidebar_layout.addWidget(self.nav_buttons["workflows"])
 
         # Metrics button
-        self.nav_buttons["metrics"] = self.create_nav_button("Metrics", 6)
+        self.nav_buttons["metrics"] = self.create_nav_button("Metrics", 7)
         sidebar_layout.addWidget(self.nav_buttons["metrics"])
 
         # Docs button
-        self.nav_buttons["docs"] = self.create_nav_button("Docs", 7)
+        self.nav_buttons["docs"] = self.create_nav_button("Docs", 8)
         sidebar_layout.addWidget(self.nav_buttons["docs"])
         
         # Add stretcher to push settings button to bottom
@@ -198,6 +203,7 @@ class AIChatApp(QMainWindow):
         self.chat_tab = ChatTab(self)
         self.agents_tab = AgentsTab(self)
         self.tools_tab = ToolsTab(self)
+        self.plugins_tab = PluginsTab(self)
         self.automations_tab = AutomationsTab(self)
         self.tasks_tab = TasksTab(self)
         self.workflows_tab = WorkflowsTab(self)
@@ -208,6 +214,7 @@ class AIChatApp(QMainWindow):
         self.content_stack.addWidget(self.chat_tab)
         self.content_stack.addWidget(self.agents_tab)
         self.content_stack.addWidget(self.tools_tab)
+        self.content_stack.addWidget(self.plugins_tab)
         self.content_stack.addWidget(self.automations_tab)
         self.content_stack.addWidget(self.tasks_tab)
         self.content_stack.addWidget(self.workflows_tab)
@@ -319,7 +326,7 @@ class AIChatApp(QMainWindow):
     def setup_keyboard_shortcuts(self):
         """Set up keyboard shortcuts for navigation and actions."""
         # Tab navigation shortcuts
-        for i, key in enumerate(['1', '2', '3', '4', '5', '6', '7', '8']):
+        for i, key in enumerate(['1', '2', '3', '4', '5', '6', '7', '8', '9']):
             shortcut = QShortcut(f"Ctrl+{key}", self)
             shortcut.activated.connect(lambda idx=i: self.change_tab(idx, self.nav_buttons[list(self.nav_buttons.keys())[idx]]))
         
@@ -376,20 +383,24 @@ class AIChatApp(QMainWindow):
     
     def show_keyboard_shortcuts(self):
         """Show keyboard shortcuts dialog."""
-        QMessageBox.information(self, "Keyboard Shortcuts",
-                              "Ctrl+1: Chat Tab\n"
-                              "Ctrl+2: Agents Tab\n"
-                              "Ctrl+3: Tools Tab\n"
-                              "Ctrl+4: Automations Tab\n"
-                              "Ctrl+5: Workflows Tab\n"
-                              "Ctrl+6: Metrics Tab\n"
-                              "Ctrl+7: Docs Tab\n"
-                              "Ctrl+S: Send Message\n"
-                              "Ctrl+L: Clear Chat\n"
-                              "Ctrl+T: Toggle Theme\n"
-                              "Ctrl+Q: Quit\n"
-                              "Ctrl+K: Show Shortcuts\n"
-                              "Ctrl+,: Open Settings")
+        QMessageBox.information(
+            self,
+            "Keyboard Shortcuts",
+            "Ctrl+1: Chat Tab\n"
+            "Ctrl+2: Agents Tab\n"
+            "Ctrl+3: Tools Tab\n"
+            "Ctrl+4: Plugins Tab\n"
+            "Ctrl+5: Automations Tab\n"
+            "Ctrl+6: Tasks Tab\n"
+            "Ctrl+7: Workflows Tab\n"
+            "Ctrl+8: Metrics Tab\n"
+            "Ctrl+9: Docs Tab\n"
+            "Ctrl+S: Send Message\n"
+            "Ctrl+L: Clear Chat\n"
+            "Ctrl+T: Toggle Theme\n"
+            "Ctrl+Q: Quit\n"
+            "Ctrl+K: Show Shortcuts\n"
+            "Ctrl+,: Open Settings")
     
     def show_about_dialog(self):
         """Show about dialog."""

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -57,6 +57,13 @@ Bundled plugins include:
 
 Tools are triggered when an agent returns a JSON block in the format produced by `generate_tool_instructions_message()`.
 
+## Plugins Tab
+
+Install and manage plugin-based tools.
+1. **Install Plugin** – choose a Python file to copy into the plugins directory.
+2. **Reload** – refresh the list of installed plugins.
+3. **Enable/Disable** – check or uncheck a plugin to toggle availability.
+
 ## Automations Tab
 
 Record and play back desktop actions.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Cerebro discovers tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point.
+Cerebro discovers tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point. Use the **Plugins** tab to install new plugins or toggle existing ones.
 
 Bundled plugins:
 - **file-summarizer** – create a short summary of a text file or provided text.

--- a/tab_plugins.py
+++ b/tab_plugins.py
@@ -1,0 +1,75 @@
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QListWidget, QHBoxLayout, QPushButton,
+    QListWidgetItem, QFileDialog, QMessageBox, QStyle
+)
+from PyQt5.QtCore import Qt
+
+from tools import (
+    get_available_plugins,
+    install_plugin,
+    set_plugin_enabled,
+)
+import tools
+
+
+class PluginsTab(QWidget):
+    """UI for managing plugin-based tools."""
+
+    def __init__(self, parent_app):
+        super().__init__()
+        self.parent_app = parent_app
+
+        self.layout = QVBoxLayout(self)
+        self.setLayout(self.layout)
+
+        self.plugins_list = QListWidget()
+        self.plugins_list.itemChanged.connect(self.on_item_changed)
+        self.layout.addWidget(self.plugins_list)
+
+        btn_layout = QHBoxLayout()
+        self.install_btn = QPushButton("Install Plugin")
+        self.install_btn.setIcon(self.style().standardIcon(getattr(QStyle, "SP_DialogOpenButton")))
+        btn_layout.addWidget(self.install_btn)
+        self.reload_btn = QPushButton("Reload")
+        self.reload_btn.setIcon(self.style().standardIcon(getattr(QStyle, "SP_BrowserReload")))
+        btn_layout.addWidget(self.reload_btn)
+        self.layout.addLayout(btn_layout)
+
+        self.install_btn.clicked.connect(self.install_plugin_ui)
+        self.reload_btn.clicked.connect(self.refresh_plugins_list)
+
+        self.refresh_plugins_list()
+
+    def refresh_plugins_list(self):
+        """Reload the plugin list."""
+        self.plugins_list.blockSignals(True)
+        self.plugins_list.clear()
+        plugins = get_available_plugins(self.parent_app.debug_enabled)
+        for plug in plugins:
+            item = QListWidgetItem(f"{plug['name']}: {plug['description']}")
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Checked if plug.get("enabled") else Qt.Unchecked)
+            item.setData(Qt.UserRole, plug['name'])
+            self.plugins_list.addItem(item)
+        self.plugins_list.blockSignals(False)
+        # Update loaded tools without triggering notifications
+        self.parent_app.tools = tools.load_tools(self.parent_app.debug_enabled)
+        if hasattr(self.parent_app.tools_tab, "refresh_tools_list"):
+            self.parent_app.tools_tab.tools = self.parent_app.tools
+            self.parent_app.tools_tab.refresh_tools_list()
+
+    def on_item_changed(self, item):
+        name = item.data(Qt.UserRole)
+        enabled = item.checkState() == Qt.Checked
+        set_plugin_enabled(name, enabled)
+        self.parent_app.refresh_tools_list()
+
+    def install_plugin_ui(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Select Plugin", "", "Python Files (*.py)")
+        if not path:
+            return
+        err = install_plugin(path, self.parent_app.debug_enabled)
+        if err:
+            QMessageBox.warning(self, "Install Error", err)
+        self.refresh_plugins_list()
+

--- a/tests/test_plugin_management.py
+++ b/tests/test_plugin_management.py
@@ -1,0 +1,26 @@
+import os
+import importlib.util
+import tools
+
+
+def test_install_and_toggle_plugin(tmp_path, monkeypatch):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    plugins_file = tmp_path / "plugins.json"
+    monkeypatch.setattr(tools, "PLUGIN_DIR", str(plugin_dir))
+    monkeypatch.setattr(tools, "PLUGINS_FILE", str(plugins_file))
+
+    plugin_src = tmp_path / "demo.py"
+    plugin_src.write_text("TOOL_METADATA={'name':'demo','description':'d'}\n\n" "def run_tool(args):\n    return 'ok'")
+
+    err = tools.install_plugin(str(plugin_src))
+    assert err is None
+    assert (plugin_dir / "demo.py").exists()
+
+    tools_list = tools.discover_plugin_tools()
+    assert any(t["name"] == "demo" for t in tools_list)
+
+    tools.set_plugin_enabled("demo", False)
+    tools_list = tools.discover_plugin_tools()
+    assert all(t["name"] != "demo" for t in tools_list)
+


### PR DESCRIPTION
## Summary
- add plugin management API in tools
- create PluginsTab for installing and toggling plugins
- wire Plugins tab into the main window
- document plugin management UI
- test plugin installation and enabling

## Testing
- `flake8 tab_plugins.py tools.py tests/test_plugin_management.py app.py | head`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843d78c4018832687c13f196ed702b8