### PR TITLE
Fix untracked update check threads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1213,12 +1213,19 @@ class AIChatApp(QMainWindow):
         thread = QThread()
         worker = UpdateCheckWorker(self.tools, self.debug_enabled)
         worker.moveToThread(thread)
+        self.active_worker_threads.append((worker, thread))
 
         def done(msg):
             if "Update available" in msg or manual:
                 self.show_notification(msg)
             thread.quit()
             thread.wait()
+            for i, (w, t) in enumerate(self.active_worker_threads):
+                if w is worker:
+                    del self.active_worker_threads[i]
+                    break
+            worker.deleteLater()
+            thread.deleteLater()
 
         worker.finished.connect(done)
         thread.started.connect(worker.run)


### PR DESCRIPTION
## Summary
- ensure update checker threads remain tracked until finished

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843db190750832682c5c12dcc244218