### PR TITLE
Add fine tuning dataset utilities

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -1,0 +1,59 @@
+"""Utilities for dataset handling during fine-tuning."""
+
+from pathlib import Path
+from typing import List, Dict
+import csv
+import json
+
+
+def validate_dataset_path(path: str) -> bool:
+    """Return True if the path is an existing CSV or JSON file."""
+    p = Path(path)
+    return p.is_file() and p.suffix.lower() in {".csv", ".json"}
+
+
+def _load_json(path: Path) -> List[Dict[str, str]]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        for key in ("data", "records", "samples"):
+            if key in data and isinstance(data[key], list):
+                data = data[key]
+                break
+        else:
+            data = [data]
+    if not isinstance(data, list):
+        raise ValueError("JSON dataset must be a list of records")
+    result = []
+    for rec in data:
+        if not isinstance(rec, dict):
+            continue
+        prompt = rec.get("prompt", "")
+        completion = rec.get("completion", "")
+        result.append({"prompt": prompt, "completion": completion})
+    return result
+
+
+def _load_csv(path: Path) -> List[Dict[str, str]]:
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        return [
+            {"prompt": row.get("prompt", ""), "completion": row.get("completion", "")}
+            for row in reader
+        ]
+
+
+def convert_dataset_format(path: str) -> List[Dict[str, str]]:
+    """Load a CSV/JSON dataset and return list of prompt/completion dictionaries."""
+    p = Path(path)
+    if p.suffix.lower() == ".json":
+        return _load_json(p)
+    if p.suffix.lower() == ".csv":
+        return _load_csv(p)
+    raise ValueError("Unsupported dataset format")
+
+
+def preview_dataset_samples(path: str, num_samples: int = 5) -> List[Dict[str, str]]:
+    """Return the first ``num_samples`` items of the dataset for preview."""
+    data = convert_dataset_format(path)
+    return data[:num_samples]

--- a/tests/test_fine_tuning.py
+++ b/tests/test_fine_tuning.py
@@ -1,0 +1,47 @@
+import json
+import csv
+from fine_tuning import validate_dataset_path, convert_dataset_format, preview_dataset_samples
+
+
+def test_validate_dataset_path(tmp_path):
+    json_file = tmp_path / "data.json"
+    json_file.write_text("[]")
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("prompt,completion\n")
+    assert validate_dataset_path(str(json_file))
+    assert validate_dataset_path(str(csv_file))
+    assert not validate_dataset_path(str(tmp_path / "missing.json"))
+    assert not validate_dataset_path(str(tmp_path / "file.txt"))
+
+
+def test_convert_dataset_format_json(tmp_path):
+    data = [
+        {"prompt": "hi", "completion": "hello"},
+        {"prompt": "bye", "completion": "goodbye"},
+    ]
+    json_file = tmp_path / "d.json"
+    json_file.write_text(json.dumps(data))
+    result = convert_dataset_format(str(json_file))
+    assert result == data
+
+
+def test_convert_dataset_format_csv(tmp_path):
+    csv_file = tmp_path / "d.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["prompt", "completion"])
+        writer.writeheader()
+        writer.writerow({"prompt": "a", "completion": "b"})
+    result = convert_dataset_format(str(csv_file))
+    assert result == [{"prompt": "a", "completion": "b"}]
+
+
+def test_preview_dataset_samples(tmp_path):
+    data = [
+        {"prompt": "p1", "completion": "c1"},
+        {"prompt": "p2", "completion": "c2"},
+        {"prompt": "p3", "completion": "c3"},
+    ]
+    json_file = tmp_path / "d.json"
+    json_file.write_text(json.dumps(data))
+    preview = preview_dataset_samples(str(json_file), num_samples=2)
+    assert preview == data[:2]


### PR DESCRIPTION
## Summary
- implement dataset validation, preview, and conversion helpers
- add unit tests for fine tuning helpers

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843db75143c8326adfbfaf793062daf