### PR TITLE
Add model fine-tuning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,30 @@ Open the "Docs" tab or press `Ctrl+7` to view the full user guide.
     ```
 
     *   To enable debug mode, set the `DEBUG_MODE` environment variable to 1:
+
         *   **Linux/macOS:** `DEBUG_MODE=1 python main.py`
         *   **Windows:** `set DEBUG_MODE=1 & python main.py`
+
+## Fine-tuning a Model
+
+Fine-tuning lets you adapt an existing model with your own dataset. Make sure
+Ollama is installed and that the base model has been pulled. Collect your
+training data in a JSONL file and create a simple `Modelfile` referencing both
+the base model and the dataset:
+
+```bash
+FROM llama3
+ADAPTER ./train.jsonl
+```
+
+Train the new model and run it with:
+
+```bash
+ollama create my-model -f Modelfile
+ollama run my-model
+```
+
+Select `my-model` in your agent settings to use it in Cerebro.
 
 ## Windows Installer
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,3 +8,17 @@ This guide has been split into separate pages. Select a topic in the Docs tab to
 - [Plugins](plugins.md)
 
 The application notifies you when an update is available and you can check manually from the Help menu.
+
+## Fine-tuning a Model
+
+Fine-tuning allows you to specialize a base model with your own examples. Ensure
+Ollama is installed and that you have pulled the model you want to adapt. Place
+your training pairs in `train.jsonl` and create a `Modelfile` similar to:
+
+```bash
+FROM llama3
+ADAPTER ./train.jsonl
+```
+
+Run `ollama create my-model -f Modelfile` and then `ollama run my-model` to test
+the result. Start the Ollama server and choose `my-model` within Cerebro.


### PR DESCRIPTION
## Summary
- document how to fine-tune a model in README
- add fine-tuning instructions to the user guide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843db79b0ec832695fd9085bc6062b3