### PR TITLE
Add fine tuning tests

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+import local_llm_helper as llh
+
+
+def train_model(dataset_path: str, base_model: str) -> list[str]:
+    """Fine-tune a model using the given dataset and refresh the installed model list."""
+    path = Path(dataset_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Dataset '{dataset_path}' not found")
+
+    subprocess.run(["ollama", "create", base_model, str(path)], check=True)
+    return llh.get_installed_models()

--- a/tests/test_fine_tuning.py
+++ b/tests/test_fine_tuning.py
@@ -1,0 +1,24 @@
+import pytest
+import fine_tuning
+import local_llm_helper as llh
+
+
+def test_train_invalid_dataset(monkeypatch):
+    monkeypatch.setattr(fine_tuning.Path, "exists", lambda self: False)
+    with pytest.raises(FileNotFoundError):
+        fine_tuning.train_model("missing.jsonl", "mistral")
+
+
+def test_model_list_refreshed(monkeypatch):
+    monkeypatch.setattr(fine_tuning.Path, "exists", lambda self: True)
+    called = {}
+
+    def fake_run(args, check=True):
+        called["args"] = args
+
+    monkeypatch.setattr(fine_tuning.subprocess, "run", fake_run)
+    monkeypatch.setattr(llh, "get_installed_models", lambda: ["new-model"])
+
+    models = fine_tuning.train_model("data.jsonl", "mistral")
+    assert models == ["new-model"]
+    assert called["args"][0] == "ollama"


### PR DESCRIPTION
## Summary
- add a helper module for running fine-tuning with Ollama
- test invalid dataset handling and model list refresh

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843db7afb9c83268ebef74245f25dad