### PR TITLE
Add model registration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Open the "Docs" tab or press `Ctrl+7` to view the full user guide.
     ```bash
     python local_llm_helper.py install
     python local_llm_helper.py download llama3
+    # After fine-tuning a model
+    python local_llm_helper.py register my-model path/to/model output_models
     ```
 
 ## Usage

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -25,6 +25,7 @@ Follow these steps to set up Cerebro.
    ```bash
    python local_llm_helper.py install
    python local_llm_helper.py download llama3
+   python local_llm_helper.py register my-model path/to/model output_models
    ```
 5. Start the Ollama server separately and then run the application:
    ```bash

--- a/local_llm_helper.py
+++ b/local_llm_helper.py
@@ -3,6 +3,7 @@ import platform
 import shutil
 import subprocess
 from pathlib import Path
+import json
 
 
 def check_ollama_installed() -> bool:
@@ -62,6 +63,64 @@ def get_installed_models() -> list[str]:
     return models
 
 
+def register_trained_model(model_name: str, model_path: str, dest_dir: str,
+                           agents_file: str = "agents.json") -> list[str]:
+    """Move the trained model and update agents.json.
+
+    Parameters
+    ----------
+    model_name: str
+        Name used by Ollama to reference the model.
+    model_path: str
+        Path to the trained model file or directory.
+    dest_dir: str
+        Directory where the model should be stored.
+    agents_file: str
+        Path to the agents.json configuration file.
+
+    Returns
+    -------
+    list[str]
+        The refreshed list of installed models.
+    """
+    src = Path(model_path)
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    if src.is_dir():
+        shutil.move(str(src), str(dest / src.name))
+    else:
+        shutil.move(str(src), str(dest / src.name))
+
+    agents_path = Path(agents_file)
+    agents = {}
+    if agents_path.exists():
+        with agents_path.open("r", encoding="utf-8") as f:
+            agents = json.load(f)
+
+    if not any(a.get("model") == model_name for a in agents.values()):
+        agents[f"{model_name} Agent"] = {
+            "model": model_name,
+            "temperature": 0.7,
+            "max_tokens": 512,
+            "system_prompt": "",
+            "enabled": False,
+            "color": "#000000",
+            "desktop_history_enabled": False,
+            "screenshot_interval": 5,
+            "role": "Assistant",
+            "description": "A new assistant agent.",
+            "managed_agents": [],
+            "tool_use": False,
+            "tools_enabled": [],
+            "automations_enabled": [],
+            "tts_voice": "",
+        }
+        with agents_path.open("w", encoding="utf-8") as f:
+            json.dump(agents, f, indent=2)
+
+    return get_installed_models()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Local LLM deployment helper")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -69,6 +128,10 @@ def main() -> None:
     dl = sub.add_parser("download", help="Download a model")
     dl.add_argument("model", help="Model name to download")
     sub.add_parser("serve", help="Start the Ollama server")
+    reg = sub.add_parser("register", help="Register a trained model")
+    reg.add_argument("model_name", help="Model name")
+    reg.add_argument("model_path", help="Path to the trained model file or folder")
+    reg.add_argument("dest_dir", help="Directory to store the model")
     args = parser.parse_args()
 
     if args.cmd == "install":
@@ -77,6 +140,13 @@ def main() -> None:
         download_model(args.model)
     elif args.cmd == "serve":
         start_server()
+    elif args.cmd == "register":
+        models = register_trained_model(
+            args.model_name,
+            args.model_path,
+            args.dest_dir,
+        )
+        print("\n".join(models))
 
 
 if __name__ == "__main__":

--- a/tests/test_local_llm_helper.py
+++ b/tests/test_local_llm_helper.py
@@ -1,3 +1,4 @@
+import json
 import local_llm_helper as llh
 
 
@@ -17,3 +18,26 @@ def test_get_installed_models(monkeypatch):
 
     monkeypatch.setattr(llh.subprocess, "run", fake_run)
     assert llh.get_installed_models() == ["model1", "model2"]
+
+
+def test_register_trained_model(tmp_path, monkeypatch):
+    model_file = tmp_path / "model.bin"
+    model_file.write_text("data")
+    dest = tmp_path / "models"
+    agents = tmp_path / "agents.json"
+    agents.write_text("{}")
+
+    monkeypatch.setattr(llh, "get_installed_models", lambda: ["my-model"])
+
+    models = llh.register_trained_model(
+        "my-model",
+        str(model_file),
+        str(dest),
+        str(agents),
+    )
+
+    assert (dest / "model.bin").exists()
+    assert "my-model" in models
+    with agents.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert any(a.get("model") == "my-model" for a in data.values())


### PR DESCRIPTION
## Summary
- support registering new models with `register_trained_model`
- expose a `register` command via `local_llm_helper.py`
- document registering fine-tuned models in README and getting started guide
- test model registration logic

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843db78996c83269bc33bc717ff5561