### PR TITLE
Add fine-tuning runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ ollama run my-model
 
 Select `my-model` in your agent settings to use it in Cerebro.
 
+You can also launch training directly from the **Finetune** tab. Cerebro uses
+the Hugging Face `transformers` library to fine-tune in a background thread and
+streams progress to the UI.
+
 ## Windows Installer
 
 Use PyInstaller to create a stand-alone Windows build. First install PyInstaller and then run `build_windows_installer.bat` from a command prompt. The executable will be created in the `dist` directory.

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -117,6 +117,8 @@ Prepare datasets and parameters to train a custom model.
 - **Learning Rate** – optimizer step size.
 - **Epochs** – number of passes over the dataset.
 - **Batch Size** – how many samples per batch.
+Start training with the **Start Training** button. Logs stream to a dialog while
+the process runs in the background.
 
 ## Documentation Tab
 


### PR DESCRIPTION
## Summary
- implement start_fine_tune for supervised training using transformers
- add TrainingDialog UI and hook up Start Training button
- test the new fine-tuning thread logic
- document how to launch fine-tuning from the Finetune tab

## Testing
- `flake8 fine_tuning.py tab_finetune.py tests/test_fine_tuning.py --max-line-length=120`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843e0ed860c8326a74edb24ef0b725f