### PR TITLE
Improve model validation for fine-tuning

### DIFF
--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -93,6 +93,16 @@ def start_fine_tune(
     """
 
     def train() -> None:
+        if ":" in model:
+            msg = (
+                f"Invalid model identifier '{model}'. "
+                "Use a Hugging Face repo id or local path instead of an "
+                "Ollama-style name."
+            )
+            if log_callback:
+                log_callback(msg)
+            return
+
         from datasets import load_dataset
         from transformers import (
             AutoModelForCausalLM,

--- a/tests/test_fine_tuning.py
+++ b/tests/test_fine_tuning.py
@@ -181,3 +181,15 @@ def test_start_fine_tune_progress_and_cancel(monkeypatch):
     thread.join()
 
     assert progress[-1] == 100.0
+
+
+def test_start_fine_tune_invalid_model(monkeypatch):
+    logs = []
+
+    monkeypatch.setitem(sys.modules, "datasets", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "transformers", types.SimpleNamespace())
+
+    thread = start_fine_tune("gemma3:12b", "data.json", {}, log_callback=logs.append)
+    thread.join()
+
+    assert any("Invalid model identifier" in log for log in logs)


### PR DESCRIPTION
## Summary
- validate model names before fine-tuning
- test invalid model handling

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ef670d2883268b063b2c7872ad3e