### PR TITLE
Enable debug logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Open the "Docs" tab or press `Ctrl+7` to view the full user guide.
     python main.py
     ```
 
-    *   To enable debug mode, set the `DEBUG_MODE` environment variable to 1:
+    *   Debug mode is enabled by default. Set the `DEBUG_MODE` environment variable to 0 to disable it:
 
-        *   **Linux/macOS:** `DEBUG_MODE=1 python main.py`
-        *   **Windows:** `set DEBUG_MODE=1 & python main.py`
+        *   **Linux/macOS:** `DEBUG_MODE=0 python main.py`
+        *   **Windows:** `set DEBUG_MODE=0 & python main.py`
 
 ## Fine-tuning a Model
 
@@ -261,7 +261,7 @@ This file stores the configuration for each agent.
 settings.json
 This file stores global application settings.
 
-debug_enabled: Enables debug mode (boolean).
+debug_enabled: Enables debug mode (boolean, default true).
 include_image: Currently unused.
 include_screenshot: Deprecated.
 image_path: Currently unused.

--- a/app.py
+++ b/app.py
@@ -78,11 +78,11 @@ class AIChatApp(QMainWindow):
     def __init__(self):
         super().__init__()
         
-        # Check for debug mode
-        if os.environ.get("DEBUG_MODE", "") == "1":
-            self.debug_enabled = True
-        else:
+        # Check for debug mode (enabled by default)
+        if os.environ.get("DEBUG_MODE", "1") == "0":
             self.debug_enabled = False
+        else:
+            self.debug_enabled = True
 
         # Basic window settings
         self.setWindowTitle("Cerebro 1.0")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,4 +24,4 @@ summaries.
 
 ## Debug Mode
 
-Set `DEBUG_MODE=1` before launching to enable verbose console logging. This helps diagnose issues with tools or agent configuration.
+Debug mode is enabled by default. Set `DEBUG_MODE=0` before launching to disable verbose console logging.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -31,6 +31,6 @@ Follow these steps to set up Cerebro.
    ```bash
    python main.py
    ```
-   Set the environment variable `DEBUG_MODE=1` to enable verbose logging.
+   Debug logging is enabled by default. Set the environment variable `DEBUG_MODE=0` to disable it.
 
 To create a Windows installer, install PyInstaller and run `build_windows_installer.bat`. The resulting executable will appear in the `dist` directory.


### PR DESCRIPTION
## Summary
- default debug mode to on
- document how to disable debug mode

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446b9478208326b9a508f076932b79