### PR TITLE
Add model naming option for fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Metrics Dashboard:**
     *   View tool usage frequency, completed tasks, and agent response times.
 *   **Finetune Tab:**
-    *   Choose an installed model and datasets to fine-tune a new version.
+    *   Choose an installed model, set a new model name, and pick datasets to fine-tune a version.
 *   **Documentation Tab:**
     *   Browse the built-in user guide. Documentation is split across multiple pages for easier navigation.
 

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -112,6 +112,7 @@ View statistics from `metrics.json`.
 
 Prepare datasets and parameters to train a custom model.
 - **Base Model** – choose from installed Ollama models.
+- **Model Name** – optional name for the trained model.
 - **Training Dataset** – path to your training file.
 - **Validation Dataset** – optional file for validation.
 - **Learning Rate** – optimizer step size.

--- a/fine_tuning.py
+++ b/fine_tuning.py
@@ -67,6 +67,7 @@ def start_fine_tune(
     log_callback: Optional[Callable[[str], None]] = None,
     progress_callback: Optional[Callable[[float], None]] = None,
     stop_event: Optional[threading.Event] = None,
+    model_name: Optional[str] = None,
 ) -> threading.Thread:
     """Start supervised fine-tuning in a background thread.
 
@@ -78,13 +79,15 @@ def start_fine_tune(
         Path to the training dataset (CSV or JSON).
     params: dict
         Training parameters (``learning_rate``, ``epochs``, ``batch_size`` and
-        ``output_dir``).
+        ``output_dir``). ``output_dir`` defaults to ``model_name`` if provided.
     log_callback: Callable[[str], None], optional
         Function called with log messages during training.
     progress_callback: Callable[[float], None], optional
         Receives progress percentage updates from 0-100.
     stop_event: threading.Event, optional
         Event that can be set to request training cancellation.
+    model_name: str, optional
+        Name for the trained model. Used as the default output directory.
 
     Returns
     -------
@@ -129,7 +132,7 @@ def start_fine_tune(
         model_obj = AutoModelForCausalLM.from_pretrained(model)
         collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
         args = TrainingArguments(
-            output_dir=params.get("output_dir", "ft_model"),
+            output_dir=params.get("output_dir", model_name or "ft_model"),
             num_train_epochs=params.get("epochs", 1),
             learning_rate=params.get("learning_rate", 5e-5),
             per_device_train_batch_size=params.get("batch_size", 2),

--- a/tab_finetune.py
+++ b/tab_finetune.py
@@ -60,6 +60,9 @@ class FinetuneTab(QWidget):
         self.refresh_models()
         layout.addRow(QLabel("Base Model:"), self.model_combo)
 
+        self.name_edit = QLineEdit()
+        layout.addRow("Model Name:", self.name_edit)
+
         # Training dataset path
         self.train_edit = QLineEdit()
         train_browse = QPushButton("Browse")
@@ -120,6 +123,7 @@ class FinetuneTab(QWidget):
         """Start fine-tuning using the selected options."""
         model = self.model_combo.currentText()
         train_path = self.train_edit.text().strip()
+        model_name = self.name_edit.text().strip()
         if not model or not train_path:
             QMessageBox.warning(self, "Finetune", "Model and training dataset are required.")
             return
@@ -129,6 +133,8 @@ class FinetuneTab(QWidget):
             "epochs": self.epochs_input.value(),
             "batch_size": self.batch_input.value(),
         }
+        if model_name:
+            params["output_dir"] = model_name
 
         dlg = TrainingDialog(model, self)
         dlg.show()
@@ -150,6 +156,7 @@ class FinetuneTab(QWidget):
             log_callback=log,
             progress_callback=progress,
             stop_event=stop_event,
+            model_name=model_name or None,
         )
         dlg.finished.connect(stop_event.set)
         dlg.thread = thread

--- a/tests/test_tab_finetune.py
+++ b/tests/test_tab_finetune.py
@@ -15,3 +15,25 @@ def test_combo_populated(monkeypatch):
     assert tab.lr_input.value() > 0
     app.quit()
 
+
+def test_model_name_passthrough(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(tab_finetune, "get_installed_models", lambda: ["m"])
+    captured = {}
+
+    def dummy_start(*args, **kwargs):
+        captured.update({"args": args, "kwargs": kwargs})
+        class DummyThread:
+            def join(self):
+                pass
+        return DummyThread()
+
+    monkeypatch.setattr(tab_finetune, "start_fine_tune", dummy_start)
+    tab = tab_finetune.FinetuneTab(DummyApp())
+    tab.train_edit.setText("train.json")
+    tab.name_edit.setText("named-model")
+    tab.start_training()
+    assert captured["kwargs"].get("model_name") == "named-model"
+    assert captured["args"][2]["output_dir"] == "named-model"
+    app.quit()
+


### PR DESCRIPTION
## Summary
- allow specifying a `model_name` when starting fine-tuning
- expose model name entry in the Finetune tab UI
- document the option in README and user docs
- test that the name flows to the training routine

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446b8ebd388326abb7b6181f692ede