### PR TITLE
Allow custom model IDs for fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Cerebro is a desktop chat application built with PyQt5 that allows you to intera
 *   **Metrics Dashboard:**
     *   View tool usage frequency, completed tasks, and agent response times.
 *   **Finetune Tab:**
-    *   Choose an installed model, set a new model name, and pick datasets to fine-tune a version.
+    *   Select an installed model or type a Hugging Face repo id, set a new model name, and pick datasets to fine-tune a version.
 *   **Documentation Tab:**
     *   Browse the built-in user guide. Documentation is split across multiple pages for easier navigation.
 

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -111,7 +111,7 @@ View statistics from `metrics.json`.
 ## Finetune Tab
 
 Prepare datasets and parameters to train a custom model.
-- **Base Model** – choose from installed Ollama models.
+- **Base Model** – select an installed Ollama model or type a Hugging Face repo id or local path.
 - **Model Name** – optional name for the trained model.
 - **Training Dataset** – path to your training file.
 - **Validation Dataset** – optional file for validation.

--- a/tab_finetune.py
+++ b/tab_finetune.py
@@ -57,6 +57,7 @@ class FinetuneTab(QWidget):
 
         # Base model selection
         self.model_combo = QComboBox()
+        self.model_combo.setEditable(True)
         self.refresh_models()
         layout.addRow(QLabel("Base Model:"), self.model_combo)
 

--- a/tests/test_tab_finetune.py
+++ b/tests/test_tab_finetune.py
@@ -12,6 +12,7 @@ def test_combo_populated(monkeypatch):
     monkeypatch.setattr(tab_finetune, "get_installed_models", lambda: ["m1", "m2"])
     tab = tab_finetune.FinetuneTab(DummyApp())
     assert tab.model_combo.count() == 2
+    assert tab.model_combo.isEditable()
     assert tab.lr_input.value() > 0
     app.quit()
 


### PR DESCRIPTION
## Summary
- make base model combo editable so users can type Hugging Face repo IDs
- update docs describing editable model field
- test editable combo behaviour

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447d1b2f608326955f29c0f325528d