### PR TITLE
Add HuggingFace authentication tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ args: (optional) List of argument names the tool accepts.
 script: The content of the Python script that implements the tool. The script must define a function called run_tool(args) that takes a dictionary of arguments and returns a string.
 script_path: (optional) Path to a Python file containing the tool implementation. If script_path is missing but script is provided, the application will run the script from a temporary file.
 Tools placed in the `tool_plugins` directory or installed via the `cerebro_tools` entry point
-are loaded automatically on startup. Built-in plugins include `math-solver` for complex calculations and `credential-manager` for secure credential storage.
+are loaded automatically on startup. Built-in plugins include `math-solver` for complex calculations, `credential-manager` for secure credential storage and `huggingface-auth` for logging in to Hugging Face.
 Example:
 
 '''JSON

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -111,7 +111,7 @@ View statistics from `metrics.json`.
 ## Finetune Tab
 
 Prepare datasets and parameters to train a custom model.
-- **Base Model** – select an installed Ollama model or type a Hugging Face repo id or local path.
+- **Base Model** – select an installed Ollama model or type a Hugging Face repo id or local path. The repo id is the portion of the model URL after `https://huggingface.co/`.
 - **Model Name** – optional name for the trained model.
 - **Training Dataset** – path to your training file.
 - **Validation Dataset** – optional file for validation.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,13 +21,17 @@ Follow these steps to set up Cerebro.
    ```bash
    pip install -r requirements.txt
    ```
-4. (Optional) Use the helper script to install Ollama and download a model:
+4. (Optional) Authenticate with Hugging Face if you plan to download models from gated repositories:
+   ```bash
+   python -m huggingface_hub login
+   ```
+5. (Optional) Use the helper script to install Ollama and download a model:
    ```bash
    python local_llm_helper.py install
    python local_llm_helper.py download llama3
    python local_llm_helper.py register my-model path/to/model output_models
    ```
-5. Start the Ollama server separately and then run the application:
+6. Start the Ollama server separately and then run the application:
    ```bash
    python main.py
    ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -11,6 +11,7 @@ Bundled plugins:
 - **ar-overlay** – show a small on-screen HUD message.
 - **desktop-automation** – launch programs or move files.
 - **credential-manager** – securely store credentials in the system keyring.
+- **huggingface-auth** – log in or out of Hugging Face to access gated models.
 - **update-manager** – check for new versions of Cerebro and download updates on Windows 11.
 - **run-automation** – execute a recorded button sequence with a configurable
   delay between actions (defaults to 0.5 seconds).

--- a/tab_finetune.py
+++ b/tab_finetune.py
@@ -58,6 +58,12 @@ class FinetuneTab(QWidget):
         # Base model selection
         self.model_combo = QComboBox()
         self.model_combo.setEditable(True)
+        self.model_combo.lineEdit().setPlaceholderText(
+            "Hugging Face repo id (part after huggingface.co/)"
+        )
+        self.model_combo.setToolTip(
+            "Enter the repo id, e.g. 'owner/model' from https://huggingface.co/owner/model"
+        )
         self.refresh_models()
         layout.addRow(QLabel("Base Model:"), self.model_combo)
 

--- a/tests/test_huggingface_auth.py
+++ b/tests/test_huggingface_auth.py
@@ -1,0 +1,25 @@
+import tool_plugins.huggingface_auth as hf_auth
+
+def test_login(monkeypatch):
+    called = {}
+    def fake_login(token=None, add_to_git_credential=True):
+        called['token'] = token
+    monkeypatch.setattr(hf_auth, 'login', fake_login)
+    res = hf_auth.run_tool({'token': 'abc'})
+    assert res.startswith('Logged in')
+    assert called['token'] == 'abc'
+
+
+def test_logout(monkeypatch):
+    called = {'logout': False}
+    def fake_logout():
+        called['logout'] = True
+    monkeypatch.setattr(hf_auth, 'logout', fake_logout)
+    res = hf_auth.run_tool({'action': 'logout'})
+    assert res.startswith('Logged out')
+    assert called['logout']
+
+
+def test_missing_token():
+    res = hf_auth.run_tool({'action': 'login'})
+    assert 'token' in res.lower()

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -27,3 +27,4 @@ def test_plugin_discovery():
     plugins = tools.discover_plugin_tools()
     names = [p["name"] for p in plugins]
     assert "web-scraper" in names
+    assert "huggingface-auth" in names

--- a/tool_plugins/huggingface_auth.py
+++ b/tool_plugins/huggingface_auth.py
@@ -1,0 +1,34 @@
+TOOL_METADATA = {
+    "name": "huggingface-auth",
+    "description": "Login or logout of Hugging Face to access private models.",
+    "args": ["action", "token"],
+}
+
+
+def run_tool(args):
+    """Authenticate with Hugging Face using huggingface_hub."""
+    try:
+        from huggingface_hub import login, logout
+    except Exception:
+        return "[huggingface-auth Error] huggingface_hub not installed."
+
+    action = args.get("action", "login")
+
+    if action == "login":
+        token = args.get("token")
+        if not token:
+            return "[huggingface-auth Error] 'token' is required for login."
+        try:
+            login(token=token, add_to_git_credential=True)
+            return "Logged in to Hugging Face."
+        except Exception as exc:
+            return f"[huggingface-auth Error] {exc}"
+
+    if action == "logout":
+        try:
+            logout()
+            return "Logged out of Hugging Face."
+        except Exception as exc:
+            return f"[huggingface-auth Error] {exc}"
+
+    return "[huggingface-auth Error] Invalid action."


### PR DESCRIPTION
## Summary
- add `huggingface-auth` plugin for logging in or out of Hugging Face
- clarify repo id field in Finetune tab
- document Hugging Face login and repo id usage
- list the new plugin in documentation
- test the new plugin and update plugin discovery test

## Testing
- `flake8 .` *(fails: many style errors)*
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684480650260832699fe1fd26a87d459