### PR TITLE
Add message status and typing indicator

### DIFF
--- a/tests/test_message_status.py
+++ b/tests/test_message_status.py
@@ -1,0 +1,47 @@
+import os
+from PyQt5.QtWidgets import QApplication
+import tab_chat
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyApp:
+    def __init__(self):
+        self.user_name = "User"
+        self.agents_data = {}
+        self.user_color = "#000000"
+    def show_notification(self, message, type="info"):
+        pass
+    def export_chat_histories(self):
+        pass
+    def clear_chat_histories(self):
+        pass
+    def clear_chat(self):
+        pass
+    def send_message(self, msg):
+        pass
+
+
+def test_message_status_update():
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    tab = tab_chat.ChatTab(dummy)
+    msg_id = tab.append_message_html(
+        "<span style='color:#000000'>[00:00] User:</span> hello", from_user=True
+    )
+    assert msg_id
+    assert "⏳" in tab.chat_display.toHtml()
+    tab.update_message_status(msg_id, "read")
+    html = tab.chat_display.toHtml()
+    assert "0000ff" in html
+    app.quit()
+
+
+def test_typing_indicator_name():
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    tab = tab_chat.ChatTab(dummy)
+    tab.show_typing_indicator("Alice")
+    assert "Alice is typing" in tab.typing_indicator.text()
+    tab.update_typing_indicator()
+    assert "Alice is typing" in tab.typing_indicator.text()
+    app.quit()

--- a/tool_plugins/huggingface_auth.py
+++ b/tool_plugins/huggingface_auth.py
@@ -1,15 +1,31 @@
 TOOL_METADATA = {
     "name": "huggingface-auth",
     "description": "Login or logout of Hugging Face to access private models.",
-    "args": ["action", "token"],
+"args": ["action", "token"],
 }
+
+try:
+    from huggingface_hub import login as hf_login, logout as hf_logout
+except Exception:  # pragma: no cover - optional dependency
+    hf_login = None
+    hf_logout = None
+
+
+def login(token=None, add_to_git_credential=True):
+    if hf_login is None:
+        raise RuntimeError("huggingface_hub not installed.")
+    return hf_login(token=token, add_to_git_credential=add_to_git_credential)
+
+
+def logout():
+    if hf_logout is None:
+        raise RuntimeError("huggingface_hub not installed.")
+    return hf_logout()
 
 
 def run_tool(args):
     """Authenticate with Hugging Face using huggingface_hub."""
-    try:
-        from huggingface_hub import login, logout
-    except Exception:
+    if hf_login is None or hf_logout is None:
         return "[huggingface-auth Error] huggingface_hub not installed."
 
     action = args.get("action", "login")


### PR DESCRIPTION
## Summary
- add message status tracking and icons
- show who is typing in chat
- expose login/logout wrappers for Hugging Face auth
- test chat status features

## Testing
- `flake8 tool_plugins/huggingface_auth.py tests/test_message_status.py tab_chat.py app.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845004650b48326a44594cc91b682dd