### PR TITLE
Fix empty chat messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1181,9 +1181,10 @@ class AIChatApp(QMainWindow):
             a.get("enabled", False)
             for a in self.agents_data.values()
             if not a.get("desktop_history_enabled", False)
-            and a.get("role") != 'Specialist'
+            and a.get("role") != "Specialist"
         )
-        self.chat_tab.send_button.setEnabled(any_enabled)
+        has_text = bool(self.chat_tab.user_input.toPlainText().strip())
+        self.chat_tab.send_button.setEnabled(any_enabled and has_text)
 
     def update_screenshot_timer(self):
         """Update screenshot timer based on agent settings."""

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -5,7 +5,7 @@ Use `Ctrl+1` through `Ctrl+7` to switch between tabs.
 ## Chat Tab
 
 - The Chat tab is the main interface for sending prompts to your agents.
-- Enter a prompt and press **Send** or use the 🎤 button to dictate a prompt.
+- Enter a prompt and press **Send** (enabled once text is entered) or use the 🎤 button to dictate a prompt.
 - Messages show in speech bubbles with small avatars and appear in a scrollable pane. A typing indicator shows when an agent is responding.
 - Use the menu to copy, save, export or clear the conversation.
 - Click the 🔍 button to search the current conversation.

--- a/tab_chat.py
+++ b/tab_chat.py
@@ -2,9 +2,21 @@
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QTextEdit, QPushButton, QHBoxLayout, QStyle,
-    QLabel, QSplitter, QFrame, QScrollArea, QToolButton, QMenu, QAction,
-    QFileDialog
+    QWidget,
+    QVBoxLayout,
+    QTextEdit,
+    QPushButton,
+    QHBoxLayout,
+    QStyle,
+    QLabel,
+    QSplitter,
+    QFrame,
+    QScrollArea,
+    QToolButton,
+    QMenu,
+    QAction,
+    QFileDialog,
+    QToolTip,
 )
 
 from dialogs import SearchDialog
@@ -188,6 +200,7 @@ class ChatTab(QWidget):
         self.clear_chat_button.clicked.connect(self.on_clear_chat_clicked)
         self.voice_button.clicked.connect(self.on_voice_clicked)
         self.user_input.textChanged.connect(self.adjust_input_height)
+        self.user_input.textChanged.connect(self.on_user_text_changed)
         search_btn.clicked.connect(self.show_search)
 
     def eventFilter(self, obj, event):
@@ -205,16 +218,28 @@ class ChatTab(QWidget):
         new_height = int(doc_height + 10)
         self.user_input.setFixedHeight(min(new_height, 100))
 
+    def on_user_text_changed(self):
+        """Notify the parent app to update the send button state."""
+        if hasattr(self.parent_app, "update_send_button_state"):
+            self.parent_app.update_send_button_state()
+
     def on_send_clicked(self):
         """
         Send message to the AIChatApp logic.
         """
         user_text = self.user_input.toPlainText().strip()
         if not user_text:
+            QToolTip.showText(
+                self.send_button.mapToGlobal(self.send_button.rect().center()),
+                "Cannot send an empty message",
+                self.send_button,
+            )
             return
         self.user_input.clear()
         self.user_input.setFixedHeight(40)
         self.parent_app.send_message(user_text)
+        if hasattr(self.parent_app, "update_send_button_state"):
+            self.parent_app.update_send_button_state()
 
     def on_clear_chat_clicked(self):
         """

--- a/tests/test_tab_chat.py
+++ b/tests/test_tab_chat.py
@@ -1,6 +1,7 @@
 import os
 from PyQt5.QtWidgets import QApplication
 import tab_chat
+import app as app_module
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -30,4 +31,36 @@ def test_save_conversation(tmp_path, monkeypatch):
     with open(dest, "r", encoding="utf-8") as f:
         assert f.read() == "hello world"
     assert dummy.notifications
+    app.quit()
+
+
+def test_send_button_updates_with_text(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    window = app_module.AIChatApp()
+    window.agents_data = {
+        "a": {"enabled": True, "desktop_history_enabled": False, "role": "Assistant"}
+    }
+    window.chat_tab.user_input.setPlainText("")
+    window.update_send_button_state()
+    assert not window.chat_tab.send_button.isEnabled()
+
+    window.chat_tab.user_input.setPlainText("hi")
+    window.update_send_button_state()
+    assert window.chat_tab.send_button.isEnabled()
+    window.close()
+    app.quit()
+
+
+def test_cannot_send_empty_message(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    window = app_module.AIChatApp()
+    window.agents_data = {
+        "a": {"enabled": True, "desktop_history_enabled": False, "role": "Assistant"}
+    }
+    called = []
+    monkeypatch.setattr(window, "send_message", lambda msg: called.append(msg))
+    window.chat_tab.user_input.setPlainText("")
+    window.chat_tab.on_send_clicked()
+    assert not called
+    window.close()
     app.quit()

--- a/tool_plugins/huggingface_auth.py
+++ b/tool_plugins/huggingface_auth.py
@@ -4,13 +4,18 @@ TOOL_METADATA = {
     "args": ["action", "token"],
 }
 
+try:
+    from huggingface_hub import login, logout
+except Exception:  # pragma: no cover - optional dependency
+    def login(*_args, **_kwargs):
+        raise ImportError("huggingface_hub not installed.")
+
+    def logout(*_args, **_kwargs):
+        raise ImportError("huggingface_hub not installed.")
+
 
 def run_tool(args):
     """Authenticate with Hugging Face using huggingface_hub."""
-    try:
-        from huggingface_hub import login, logout
-    except Exception:
-        return "[huggingface-auth Error] huggingface_hub not installed."
 
     action = args.get("action", "login")
 
@@ -21,6 +26,8 @@ def run_tool(args):
         try:
             login(token=token, add_to_git_credential=True)
             return "Logged in to Hugging Face."
+        except ImportError as exc:
+            return f"[huggingface-auth Error] {exc}"
         except Exception as exc:
             return f"[huggingface-auth Error] {exc}"
 
@@ -28,6 +35,8 @@ def run_tool(args):
         try:
             logout()
             return "Logged out of Hugging Face."
+        except ImportError as exc:
+            return f"[huggingface-auth Error] {exc}"
         except Exception as exc:
             return f"[huggingface-auth Error] {exc}"
 


### PR DESCRIPTION
## Summary
- prevent sending empty messages
- show tooltip when attempting to send nothing
- disable send button when input is blank
- update chat documentation
- ensure HuggingFace auth tests pass
- add tests for the new send behavior

## Testing
- `flake8 .` *(fails: E501 etc.)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684501a0ea848326a7a9a715789ccfd0