### PR TITLE
Add input validation feedback

### DIFF
--- a/tab_chat.py
+++ b/tab_chat.py
@@ -1,6 +1,12 @@
 #tab_chat.py
 from PyQt5 import QtCore
-from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtCore import (
+    Qt,
+    QTimer,
+    QPoint,
+    QPropertyAnimation,
+    QAbstractAnimation,
+)
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QTextEdit, QPushButton, QHBoxLayout, QStyle,
     QLabel, QSplitter, QFrame, QScrollArea, QToolButton, QMenu, QAction,
@@ -203,11 +209,19 @@ class ChatTab(QWidget):
         if obj == self.user_input and event.type() == QtCore.QEvent.KeyPress:
             if event.key() == QtCore.Qt.Key_Return and not event.modifiers() & QtCore.Qt.ShiftModifier:
                 if not self.user_input.toPlainText().strip():
-                    # Show a tooltip
-                    tooltip_duration = 2000 # milliseconds
-                    tooltip_position = self.user_input.mapToGlobal(self.user_input.rect().bottomLeft())
-                    QToolTip.showText(tooltip_position, "Cannot send an empty message", self.user_input, self.user_input.rect(), tooltip_duration)
-                    return True # Event handled, don't proceed to send
+                    tooltip_duration = 2000  # milliseconds
+                    tooltip_position = self.user_input.mapToGlobal(
+                        self.user_input.rect().bottomLeft()
+                    )
+                    QToolTip.showText(
+                        tooltip_position,
+                        "Cannot send an empty message",
+                        self.user_input,
+                        self.user_input.rect(),
+                        tooltip_duration,
+                    )
+                    self.shake_widget(self.user_input)
+                    return True  # Event handled, don't proceed to send
                 self.on_send_clicked()
                 return True
         return super().eventFilter(obj, event)
@@ -219,6 +233,19 @@ class ChatTab(QWidget):
             self.send_button.setEnabled(False)
         else:
             self.send_button.setEnabled(True)
+
+    def shake_widget(self, widget):
+        """Perform a subtle shake animation on the given widget."""
+        animation = QPropertyAnimation(widget, b"pos", self)
+        start_pos = widget.pos()
+        offset = 5
+        animation.setDuration(200)
+        animation.setKeyValueAt(0, start_pos)
+        animation.setKeyValueAt(0.25, start_pos + QPoint(-offset, 0))
+        animation.setKeyValueAt(0.5, start_pos + QPoint(offset, 0))
+        animation.setKeyValueAt(0.75, start_pos + QPoint(-offset, 0))
+        animation.setKeyValueAt(1, start_pos)
+        animation.start(QAbstractAnimation.DeleteWhenStopped)
 
     def adjust_input_height(self):
         doc_height = self.user_input.document().size().height()

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,29 @@
+import os
+from PyQt5.QtWidgets import QApplication
+import tab_chat
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyApp:
+    def show_notification(self, *a, **k):
+        pass
+    def export_chat_histories(self):
+        pass
+    def clear_chat_histories(self):
+        pass
+    def clear_chat(self):
+        pass
+    def send_message(self, msg):
+        pass
+
+def test_send_button_state():
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    tab = tab_chat.ChatTab(dummy)
+    tab.user_input.setPlainText("")
+    tab.update_send_button_state()
+    assert not tab.send_button.isEnabled()
+    tab.user_input.setPlainText("hi")
+    tab.update_send_button_state()
+    assert tab.send_button.isEnabled()
+    app.quit()


### PR DESCRIPTION
## Summary
- enhance ChatTab to shake on empty send attempts
- add unit test covering send button state

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684505e5d1f483269a319e0aeca95e2d