### PR TITLE
Enhance chat timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cerebro offers a rich set of features to enhance your interaction with AI models
 *   **Automations:** Record and replay desktop actions (mouse and keyboard sequences). (Details: [Application Tabs - Automations](docs/app_tabs.md#automations-tab))
 *   **Task Scheduling:** Schedule prompts for agents to run at specific times, with optional repetition and OS scheduler integration. (Details: [Application Tabs - Tasks](docs/app_tabs.md#tasks-tab))
 *   **Workflow Builder:** Design and execute reusable, multi-agent workflows. (Details: [Application Tabs - Workflows](docs/app_tabs.md#workflows-tab))
-*   **Chat Management:** Save, export, clear, and search chat history. Long conversations are automatically summarized. (Details: [Application Tabs - Chat](docs/app_tabs.md#chat-tab))
+*   **Chat Management:** Save, export, clear, and search chat history. Messages include avatars, colored names and timestamps grouped by date. Long conversations are automatically summarized. (Details: [Application Tabs - Chat](docs/app_tabs.md#chat-tab))
 *   **Desktop History:** Allow agents to receive periodic screenshots of your desktop for visual context. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab))
 *   **Customizable UI:** Includes light/dark modes, configurable colors, and a system tray icon for quick actions. (Details: [System Tray](docs/system_tray.md), [Configuration - settings.json](docs/configuration.md#settingsjson))
 *   **Metrics & Fine-tuning:** Monitor application metrics and fine-tune language models with your own datasets. (Details: [Application Tabs - Metrics](docs/app_tabs.md#metrics-tab), [Application Tabs - Finetune](docs/app_tabs.md#finetune-tab), [User Guide - Fine-tuning](docs/user_guide.md#fine-tuning-a-model))

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -6,7 +6,7 @@ Use `Ctrl+1` through `Ctrl+7` to switch between tabs.
 
 - The Chat tab is the main interface for sending prompts to your agents.
 - Enter a prompt and press **Send** or use the 🎤 button to dictate a prompt.
-- Messages show in speech bubbles with small avatars and appear in a scrollable pane. A typing indicator shows when an agent is responding.
+- Messages show in speech bubbles with avatars or initials next to the sender name. Each message includes a timestamp and conversations are grouped by date so you can quickly see when a discussion happened.
 - Use the menu to copy, save, export or clear the conversation.
 - Click the 🔍 button to search the current conversation.
 - Long conversations are automatically summarized to keep prompts short.

--- a/tab_chat.py
+++ b/tab_chat.py
@@ -1,6 +1,7 @@
 #tab_chat.py
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt, QTimer
+from datetime import datetime, timedelta
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QTextEdit, QPushButton, QHBoxLayout, QStyle,
     QLabel, QSplitter, QFrame, QScrollArea, QToolButton, QMenu, QAction,
@@ -23,6 +24,7 @@ class ChatTab(QWidget):
         self.message_counter = 0
         self.last_user_message_id = None
         self.typing_name = "Assistant"
+        self.last_date = None
 
         self.layout = QVBoxLayout(self)
         self.layout.setContentsMargins(0, 0, 0, 0)
@@ -286,9 +288,17 @@ class ChatTab(QWidget):
             avatar_html = (
                 f"<div style='font-size:20px;margin-{'left' if is_user else 'right'}:6px;'>{avatar}</div>"
             )
+            msg_time = datetime.now()
+            if self.last_date != msg_time.date():
+                label = self.format_date_label(msg_time.date())
+                self.chat_display.append(
+                    f"<div style='text-align:center;color:gray;margin:4px 0;'>--- {label} ---</div>"
+                )
+                self.last_date = msg_time.date()
+            ts_label, ts_title = self.format_timestamp(msg_time)
             bubble_html = (
                 f"<div style='background-color:{bubble_bg};color:{text_color};padding:6px;border-radius:10px;max-width:80%;'>"
-                f"<div style='font-size:10px;color:gray'>[{timestamp}] {name}</div>{message}</div>"
+                f"<div style='font-size:10px;color:gray' title='{ts_title}'>{ts_label} {name}</div>{message}</div>"
             )
             if is_user:
                 html_text = f"<div style='display:flex;justify-content:{align};margin:4px;'>{bubble_html}{avatar_html}</div>"
@@ -397,6 +407,26 @@ class ChatTab(QWidget):
         self.typing_indicator.setText(
             f"<span style='font-size:20px'>🤔</span> {self.typing_name} is typing{dots}"
         )
+
+    def format_date_label(self, date):
+        today = datetime.now().date()
+        if date == today:
+            return "Today"
+        if date == today - timedelta(days=1):
+            return "Yesterday"
+        return date.strftime("%B %d, %Y")
+
+    def format_timestamp(self, ts):
+        now = datetime.now()
+        delta = now - ts
+        if delta < timedelta(minutes=1):
+            label = f"{int(delta.total_seconds())}s ago"
+        elif delta < timedelta(hours=1):
+            label = f"{int(delta.total_seconds() // 60)}m ago"
+        else:
+            label = ts.strftime("%I:%M %p").lstrip("0")
+        title = ts.strftime("%Y-%m-%d %H:%M")
+        return label, title
 
     def get_avatar(self, name):
         if name.startswith(self.parent_app.user_name):

--- a/tests/test_tab_chat.py
+++ b/tests/test_tab_chat.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 from PyQt5.QtWidgets import QApplication
 import tab_chat
 
@@ -30,4 +31,19 @@ def test_save_conversation(tmp_path, monkeypatch):
     with open(dest, "r", encoding="utf-8") as f:
         assert f.read() == "hello world"
     assert dummy.notifications
+    app.quit()
+
+
+def test_format_helpers():
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    tab = tab_chat.ChatTab(dummy)
+    now = datetime.now()
+    label_today = tab.format_date_label(now.date())
+    label_yesterday = tab.format_date_label(now.date() - timedelta(days=1))
+    assert label_today == "Today"
+    assert label_yesterday == "Yesterday"
+    ts_label, title = tab.format_timestamp(now - timedelta(minutes=5))
+    assert ts_label == "5m ago"
+    assert title.startswith(now.strftime("%Y-%m-%d"))
     app.quit()


### PR DESCRIPTION
## Summary
- show avatars, timestamps and date separators in the chat UI
- add helper functions for timestamp formatting
- document conversation improvements
- test timestamp helpers

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684505f140d88326aea5e5733b2cbd71