### PR TITLE
Add tooltip and onboarding for Agents tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,6 +106,7 @@ class AIChatApp(QMainWindow):
         self.notifications_paused = False
         self.screenshot_paused = False
         self.summarization_threshold = 20
+        self.agents_onboarding_complete = False
         
         # Initialize notification system
         self.notifications = []
@@ -165,6 +166,7 @@ class AIChatApp(QMainWindow):
         
         # Agents button
         self.nav_buttons["agents"] = self.create_nav_button("Agents", 1)
+        self.nav_buttons["agents"].setToolTip("Manage automated workers that perform tasks.")
         sidebar_layout.addWidget(self.nav_buttons["agents"])
         
         # Tools button
@@ -342,6 +344,9 @@ class AIChatApp(QMainWindow):
     def change_tab(self, index, button=None):
         """Change the active tab and update button styles."""
         self.content_stack.setCurrentIndex(index)
+
+        if index == 1 and not self.agents_onboarding_complete:
+            self.show_agents_onboarding()
         
         # Update button styles
         for btn in self.nav_buttons.values():
@@ -417,7 +422,7 @@ class AIChatApp(QMainWindow):
             
     def show_help_dialog(self):
         """Show the help dialog."""
-        QMessageBox.information(self, "Cerebro Help", 
+        QMessageBox.information(self, "Cerebro Help",
                               "Cerebro is a multi-agent AI chat application.\n\n"
                               "• Chat: Interact with AI agents\n"
                               "• Agents: Configure your AI assistants\n"
@@ -426,6 +431,16 @@ class AIChatApp(QMainWindow):
                               "• Tasks: Schedule future agent actions\n\n"
                               "• Docs: View the built-in user guide\n\n"
                               "Press Ctrl+K to view keyboard shortcuts.")
+
+    def show_agents_onboarding(self):
+        """Display a brief onboarding message for the Agents tab."""
+        QMessageBox.information(
+            self,
+            "Welcome to Agents",
+            "Agents are automated workers that perform tasks. Configure them here."
+        )
+        self.agents_onboarding_complete = True
+        self.save_settings()
     
     def show_keyboard_shortcuts(self):
         """Show keyboard shortcuts dialog."""
@@ -1448,6 +1463,7 @@ class AIChatApp(QMainWindow):
             "dark_mode": self.dark_mode,
             "screenshot_interval": self.screenshot_interval,
             "summarization_threshold": self.summarization_threshold,
+            "agents_onboarding_complete": self.agents_onboarding_complete,
         }
         try:
             with open(SETTINGS_FILE, "w", encoding="utf-8") as f:
@@ -1475,6 +1491,9 @@ class AIChatApp(QMainWindow):
                 )
                 self.summarization_threshold = settings.get(
                     "summarization_threshold", self.summarization_threshold
+                )
+                self.agents_onboarding_complete = settings.get(
+                    "agents_onboarding_complete", False
                 )
                 if self.debug_enabled:
                     print("[Debug] Settings loaded.")

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -16,6 +16,7 @@ Use `Ctrl+1` through `Ctrl+7` to switch between tabs.
 ## Agents Tab
 
 Create, edit and delete agents.
+Agents are automated workers that perform tasks for you.
 - **Model** – select an installed Ollama model such as `llava` or `llama3.2-vision`.
 - **Temperature** – controls randomness of responses.
 - **Max Tokens** – maximum reply length (up to 100000 tokens).

--- a/tab_agents.py
+++ b/tab_agents.py
@@ -37,6 +37,10 @@ class AgentsTab(QWidget):
         self.list_page = QWidget()
         list_layout = QVBoxLayout(self.list_page)
 
+        intro_label = QLabel("Manage automated workers that perform tasks.")
+        intro_label.setWordWrap(True)
+        list_layout.addWidget(intro_label)
+
         self.agent_table = QTableWidget(0, 5)
         self.agent_table.setHorizontalHeaderLabels([
             "Name",


### PR DESCRIPTION
## Summary
- clarify Agents tab with introductory text and tooltip
- add onboarding message for first-time Agents usage
- persist onboarding completion status in settings
- document the meaning of Agents in the docs

## Testing
- `flake8 .` *(fails: E265, F401, E501, etc.)*
- `PYTHONPATH=. pytest -q` *(fails: 3 failed, 91 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6845064f69148326950132a469c67c2e