### PR TITLE
Improve agent settings layout

### DIFF
--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -16,26 +16,23 @@ Use `Ctrl+1` through `Ctrl+7` to switch between tabs.
 
 ## Agents Tab
 
-Create, edit and delete agents.
-Agents are automated workers that perform tasks for you.
-- **Model** – select an installed Ollama model such as `llava` or `llama3.2-vision`.
-- **Temperature** – controls randomness of responses.
-- **Max Tokens** – maximum reply length (up to 100000 tokens).
-- **Custom System Prompt** – instructions sent before each conversation.
-- **Enabled** – toggle the agent on or off.
-- **Role** – Assistant, Coordinator or Specialist.
-- **Description** – short summary used by Coordinators.
-- **Agent Color** – color used for chat messages.
-- **Managed Agents** – Coordinators can delegate to selected agents.
-- **Tool Use** – allow the agent to call tools.
-- **Enabled Tools** – choose which tools are available.
-- **Enable Thinking** – generate intermediate thoughts before answering.
-- **Thinking Steps** – number of thinking iterations.
-- **Text-to-Speech Enabled** – speak replies aloud.
-- **Voice** – choose which system voice to use when speaking.
-    - *Prerequisites: TTS functionality relies on the text-to-speech engines available on your operating system. Ensure you have voices installed and configured at the OS level if you encounter issues.*
-- **Desktop History Enabled** – capture screenshots for the model.
-- **Screenshot Interval** – seconds between captures.
+Create, edit and delete agents. Agents are automated workers that perform tasks for you.
+
+Agent settings are organized into three tabs for clarity:
+
+**General**
+- Name, model, role, description and color
+- Enable or disable the agent
+
+**Triggers**
+- Managed agents for coordinators
+- Tool use options and tool/automation selection
+
+**Advanced**
+- Prompt settings: temperature, max tokens and custom system prompt
+- Thinking mode and steps
+- Text-to-speech settings (voice selection)
+- Desktop history settings
 
 ### Agent Roles in Detail
 

--- a/tab_agents.py
+++ b/tab_agents.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QTableWidget, QTableWidgetItem, QPushButton,
     QHBoxLayout, QComboBox, QFrame, QLineEdit, QTextEdit, QCheckBox,
     QColorDialog, QFormLayout, QGroupBox, QDoubleSpinBox, QSpinBox,
-    QListWidget, QListWidgetItem, QMessageBox, QStackedWidget
+    QListWidget, QListWidgetItem, QMessageBox, QStackedWidget, QTabWidget
 )
 from PyQt5.QtCore import Qt
 
@@ -81,27 +81,86 @@ class AgentsTab(QWidget):
         separator.setFrameShadow(QFrame.Sunken)
         edit_layout.addWidget(separator)
 
-        # Agent settings form
-        self.agent_settings_layout = QFormLayout()
+        # Settings tabs with progressive disclosure
+        self.settings_tabs = QTabWidget()
+
+        # -------------------
+        # General tab
+        # -------------------
+        self.general_tab = QWidget()
+        self.general_form = QFormLayout(self.general_tab)
 
         # Agent name
         self.name_label = QLabel("Agent Name:")
         self.name_input = QLineEdit()
         self.name_input.setToolTip("Unique name for this agent.")
-        self.agent_settings_layout.addRow(self.name_label, self.name_input)
+        self.general_form.addRow(self.name_label, self.name_input)
 
-        # --- Basic Settings ---
         self.model_label = QLabel("Model:")
         self.model_combo = QComboBox()
         self.model_combo.setToolTip("Select the model to use for this agent.")
-        self.agent_settings_layout.addRow(self.model_label, self.model_combo)
-        
-        # --- Prompt Settings Group ---
+        self.general_form.addRow(self.model_label, self.model_combo)
+
+        self.enabled_checkbox = QCheckBox("Enable Agent")
+        self.enabled_checkbox.setToolTip("Enable or disable this agent.")
+        self.general_form.addRow("", self.enabled_checkbox)
+
+        self.role_label = QLabel("Agent Role:")
+        self.role_combo = QComboBox()
+        self.role_combo.addItems(["Assistant", "Coordinator", "Specialist"])
+        self.role_combo.setToolTip("Select the role for this agent.")
+        self.general_form.addRow(self.role_label, self.role_combo)
+
+        self.description_label = QLabel("Description:")
+        self.description_input = QLineEdit()
+        self.description_input.setToolTip("Brief description of this agent's capabilities.")
+        self.general_form.addRow(self.description_label, self.description_input)
+
+        self.color_label = QLabel("Agent Color:")
+        self.color_button = QPushButton()
+        self.color_button.setToolTip("Select a color for this agent's messages.")
+        self.color_button.setFixedWidth(80)
+        self.color_button.clicked.connect(self.on_color_button_clicked)
+        self.general_form.addRow(self.color_label, self.color_button)
+
+        # -------------------
+        # Triggers tab
+        # -------------------
+        self.triggers_tab = QWidget()
+        self.triggers_form = QFormLayout(self.triggers_tab)
+
+        self.managed_agents_label = QLabel("Managed Agents:")
+        self.managed_agents_list = QListWidget()
+        self.managed_agents_list.setToolTip("Select agents that this Coordinator can manage.")
+        self.managed_agents_list.setSelectionMode(QListWidget.MultiSelection)
+        self.triggers_form.addRow(self.managed_agents_label, self.managed_agents_list)
+
+        self.tool_use_checkbox = QCheckBox("Enable Tool Use")
+        self.tool_use_checkbox.setToolTip("Allow this agent to use tools.")
+        self.triggers_form.addRow("", self.tool_use_checkbox)
+
+        self.tools_label = QLabel("Enabled Tools:")
+        self.tools_list = QListWidget()
+        self.tools_list.setToolTip("Select tools that this agent can use.")
+        self.tools_list.setSelectionMode(QListWidget.MultiSelection)
+        self.triggers_form.addRow(self.tools_label, self.tools_list)
+
+        self.automations_label = QLabel("Enabled Automations:")
+        self.automations_list = QListWidget()
+        self.automations_list.setToolTip("Select automations that this agent can use.")
+        self.automations_list.setSelectionMode(QListWidget.MultiSelection)
+        self.triggers_form.addRow(self.automations_label, self.automations_list)
+
+        # -------------------
+        # Advanced tab
+        # -------------------
+        self.advanced_tab = QWidget()
+        self.advanced_form = QFormLayout(self.advanced_tab)
+
         self.prompt_settings_group = QGroupBox("Prompt Settings")
         self.prompt_settings_layout = QFormLayout()
         self.prompt_settings_group.setLayout(self.prompt_settings_layout)
-        
-        # Temperature setting
+
         self.temperature_label = QLabel("Temperature:")
         self.temperature_input = QDoubleSpinBox()
         self.temperature_input.setMinimum(0.0)
@@ -109,16 +168,13 @@ class AgentsTab(QWidget):
         self.temperature_input.setSingleStep(0.1)
         self.temperature_input.setToolTip("Controls randomness. Lower values produce more predictable outputs.")
         self.prompt_settings_layout.addRow(self.temperature_label, self.temperature_input)
-        
-        # Max tokens setting
+
         self.max_tokens_label = QLabel("Max Tokens:")
         self.max_tokens_input = QSpinBox()
         self.max_tokens_input.setMinimum(1)
         self.max_tokens_input.setMaximum(100000)
         self.max_tokens_input.setToolTip("Maximum number of tokens in the response.")
         self.prompt_settings_layout.addRow(self.max_tokens_label, self.max_tokens_input)
-        
-        self.agent_settings_layout.addRow(self.prompt_settings_group)
 
         self.system_prompt_label = QLabel("Custom System Prompt:")
         self.system_prompt_input = QTextEdit()
@@ -127,82 +183,37 @@ class AgentsTab(QWidget):
         self.system_prompt_input.setToolTip("Enter a custom system prompt for the agent.")
         self.prompt_settings_layout.addRow(self.system_prompt_label, self.system_prompt_input)
 
-        # --- Other Settings ---
-        self.enabled_checkbox = QCheckBox("Enable Agent")
-        self.enabled_checkbox.setToolTip("Enable or disable this agent.")
-        self.agent_settings_layout.addRow("", self.enabled_checkbox)
-        
-        # Agent role
-        self.role_label = QLabel("Agent Role:")
-        self.role_combo = QComboBox()
-        self.role_combo.addItems(["Assistant", "Coordinator", "Specialist"])
-        self.role_combo.setToolTip("Select the role for this agent.")
-        self.agent_settings_layout.addRow(self.role_label, self.role_combo)
-        
-        # Agent description
-        self.description_label = QLabel("Description:")
-        self.description_input = QLineEdit()
-        self.description_input.setToolTip("Brief description of this agent's capabilities.")
-        self.agent_settings_layout.addRow(self.description_label, self.description_input)
-        
-        # Color picker
-        self.color_label = QLabel("Agent Color:")
-        self.color_button = QPushButton()
-        self.color_button.setToolTip("Select a color for this agent's messages.")
-        self.color_button.setFixedWidth(80)
-        self.color_button.clicked.connect(self.on_color_button_clicked)
-        self.agent_settings_layout.addRow(self.color_label, self.color_button)
-        
-        # Managed agents (for Coordinator role)
-        self.managed_agents_label = QLabel("Managed Agents:")
-        self.managed_agents_list = QListWidget()
-        self.managed_agents_list.setToolTip("Select agents that this Coordinator can manage.")
-        self.managed_agents_list.setSelectionMode(QListWidget.MultiSelection)
-        self.agent_settings_layout.addRow(self.managed_agents_label, self.managed_agents_list)
-        
-        # Tool use
-        self.tool_use_checkbox = QCheckBox("Enable Tool Use")
-        self.tool_use_checkbox.setToolTip("Allow this agent to use tools.")
-        self.agent_settings_layout.addRow("", self.tool_use_checkbox)
-        
-        # Tools enabled
-        self.tools_label = QLabel("Enabled Tools:")
-        self.tools_list = QListWidget()
-        self.tools_list.setToolTip("Select tools that this agent can use.")
-        self.tools_list.setSelectionMode(QListWidget.MultiSelection)
-        self.agent_settings_layout.addRow(self.tools_label, self.tools_list)
+        self.advanced_form.addRow(self.prompt_settings_group)
 
-        # Automations enabled
-        self.automations_label = QLabel("Enabled Automations:")
-        self.automations_list = QListWidget()
-        self.automations_list.setToolTip("Select automations that this agent can use.")
-        self.automations_list.setSelectionMode(QListWidget.MultiSelection)
-        self.agent_settings_layout.addRow(self.automations_label, self.automations_list)
-
-        # Thinking options
         self.thinking_checkbox = QCheckBox("Enable Thinking")
         self.thinking_checkbox.setToolTip("Allow the agent to think in steps before answering.")
-        self.agent_settings_layout.addRow("", self.thinking_checkbox)
+        self.advanced_form.addRow("", self.thinking_checkbox)
 
         self.thinking_steps_label = QLabel("Thinking Steps:")
         self.thinking_steps_input = QSpinBox()
         self.thinking_steps_input.setMinimum(1)
         self.thinking_steps_input.setMaximum(10)
         self.thinking_steps_input.setToolTip("Number of thinking iterations before responding.")
-        self.agent_settings_layout.addRow(self.thinking_steps_label, self.thinking_steps_input)
+        self.advanced_form.addRow(self.thinking_steps_label, self.thinking_steps_input)
 
         self.tts_checkbox = QCheckBox("Text-to-Speech Enabled")
         self.tts_checkbox.setToolTip("Speak this agent's replies aloud.")
-        self.agent_settings_layout.addRow("", self.tts_checkbox)
+        self.advanced_form.addRow("", self.tts_checkbox)
 
         self.voice_combo = QComboBox()
         self.voice_combo.addItem("Default")
         for name in tts.get_available_voice_names():
             self.voice_combo.addItem(name)
         self.voice_combo.setToolTip("Select the voice used for Text-to-Speech.")
-        self.agent_settings_layout.addRow("Voice", self.voice_combo)
+        self.advanced_form.addRow("Voice", self.voice_combo)
 
-        edit_layout.addLayout(self.agent_settings_layout)
+        # Add tabs to widget
+        self.settings_tabs.addTab(self.general_tab, "General")
+        self.settings_tabs.addTab(self.triggers_tab, "Triggers")
+        self.settings_tabs.addTab(self.advanced_tab, "Advanced")
+
+        edit_layout.addWidget(self.settings_tabs)
+
 
         # Navigation buttons at the bottom
         edit_layout.addLayout(nav_layout)


### PR DESCRIPTION
## Summary
- refactor agent editor UI into General, Triggers and Advanced tabs
- document new tab-based layout in docs

## Testing
- `flake8 .` *(fails: E265 block comment should start with '# ', etc.)*
- `pytest -q` *(fails: 44 errors during collection)*
- `PYTHONPATH=. pytest tests/test_agent_delete_confirmation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68450a1c2ea4832686781bd78f2b59c5