### PR TITLE
Add contextual help for Agents tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Cerebro offers a rich set of features to enhance your interaction with AI models
 
 The most comprehensive and up-to-date documentation is available directly within the Cerebro application. Navigate to the **Docs** tab (or press `Ctrl+0`) to browse the full user guide, including detailed explanations of all features, configuration options, and development guides.
 
+Contextual help buttons (`?`) appear in the Agents tab next to complex settings. Clicking these opens the new **Agents Help** section of the documentation for quick reference.
+
 You can also view the documentation online here: **[Cerebro User Guide](docs/user_guide.md)**
 
 ## Requirements

--- a/docs/agents_help.md
+++ b/docs/agents_help.md
@@ -1,0 +1,38 @@
+# Agents Help
+
+This guide explains each option in the Agents tab and provides quick links to related documentation. Access it from the "?" buttons in the Agents tab or from the Docs tab.
+
+## Basic Settings
+
+- **Model** – the Ollama model used for this agent.
+- **Temperature** – controls randomness of responses.
+- **Max Tokens** – maximum tokens in each response.
+- **Custom System Prompt** – instructions prefixed to every conversation.
+
+## Roles
+
+Different agent roles determine how they interact with the system:
+
+- **Assistant** – standard chat assistant.
+- **Coordinator** – delegates work to other agents.
+- **Specialist** – performs focused tasks.
+
+See [Application Tabs – Agents](app_tabs.md#agents-tab) for more detail.
+
+## Tools and Automations
+
+Enable tool use so the agent can call scripts or automation sequences. You can select which tools and automations are available from the lists.
+
+For additional details see [Plugins and Tools](plugins.md) and [Application Tabs – Automations](app_tabs.md#automations-tab).
+
+## Thinking Mode
+
+When enabled, the agent generates one or more "thought" messages before producing the final answer. Increase the number of steps to allow deeper reasoning.
+
+## Text-to-Speech
+
+Speak agent replies aloud using any voice installed on your system.
+
+---
+
+For further help browse the full [User Guide](user_guide.md).

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -18,6 +18,7 @@ Select a topic from the list below or from the Docs tab within the application t
     - Metrics Tab
     - Finetune Tab (see also [Fine-tuning a Model](#fine-tuning-a-model) below)
     - Documentation Tab
+- **[Agents Help](agents_help.md):** Quick reference for agent configuration options accessed via the "?" buttons.
 - **[Configuration](configuration.md):** Explanation of the various JSON configuration files used by Cerebro (`agents.json`, `settings.json`, etc.).
 - **[Plugins and Tools](plugins.md):** Understanding how to use and develop tools and plugins for Cerebro.
 - **[System Tray](system_tray.md):** Using the system tray icon for quick actions.

--- a/tab_agents.py
+++ b/tab_agents.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QTableWidget, QTableWidgetItem, QPushButton,
     QHBoxLayout, QComboBox, QFrame, QLineEdit, QTextEdit, QCheckBox,
     QColorDialog, QFormLayout, QGroupBox, QDoubleSpinBox, QSpinBox,
-    QListWidget, QListWidgetItem, QMessageBox, QStackedWidget
+    QListWidget, QListWidgetItem, QMessageBox, QStackedWidget, QToolButton
 )
 from PyQt5.QtCore import Qt
 
@@ -53,7 +53,17 @@ class AgentsTab(QWidget):
 
         self.add_agent_btn = QPushButton("Add New Agent")
         self.add_agent_btn.clicked.connect(self.parent_app.add_agent)
-        list_layout.addWidget(self.add_agent_btn, alignment=Qt.AlignLeft)
+        btn_row = QHBoxLayout()
+        btn_row.addWidget(self.add_agent_btn)
+
+        help_btn = QToolButton()
+        help_btn.setText("?")
+        help_btn.setToolTip("Open Agents help")
+        help_btn.clicked.connect(self.open_agents_help)
+        btn_row.addWidget(help_btn)
+
+        btn_row.addStretch()
+        list_layout.addLayout(btn_row)
 
         self.stacked.addWidget(self.list_page)
 
@@ -70,7 +80,14 @@ class AgentsTab(QWidget):
         self.save_button.clicked.connect(self.on_save_agent_clicked)
         self.delete_button = QPushButton("Delete")
         self.delete_button.clicked.connect(self.on_delete_agent_clicked)
+
+        help_btn_edit = QToolButton()
+        help_btn_edit.setText("?")
+        help_btn_edit.setToolTip("Open Agents help")
+        help_btn_edit.clicked.connect(self.open_agents_help)
+
         nav_layout.addStretch()
+        nav_layout.addWidget(help_btn_edit)
         nav_layout.addWidget(self.cancel_button)
         nav_layout.addWidget(self.save_button)
         nav_layout.addWidget(self.delete_button)
@@ -577,3 +594,10 @@ class AgentsTab(QWidget):
         models = self.global_agent_preferences.get("available_models", [])
         self.model_combo.addItems(models)
         self.model_combo.blockSignals(False)
+
+    def open_agents_help(self):
+        """Open the documentation tab to the Agents Help section."""
+        app = self.parent_app
+        app.change_tab(9, app.nav_buttons.get("docs"))
+        if "Agents Help" in app.docs_tab.doc_map:
+            app.docs_tab.selector.setCurrentText("Agents Help")

--- a/tab_docs.py
+++ b/tab_docs.py
@@ -19,6 +19,7 @@ class DocumentationTab(QWidget):
             "Application Tabs": "app_tabs.md",
             "Configuration": "configuration.md",
             "Plugins": "plugins.md",
+            "Agents Help": "agents_help.md",
         }
         self.selector.addItems(self.doc_map.keys())
         self.selector.currentTextChanged.connect(self.load_documentation)


### PR DESCRIPTION
## Summary
- add Agents Help section in documentation
- update Documentation tab to include new Agents Help page
- add help buttons to Agents tab linking to relevant docs
- mention help feature in README and User Guide

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450a3834288326aa2dc4705d133250