### PR TITLE
Add task progress indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cerebro offers a rich set of features to enhance your interaction with AI models
 *   **Thinking Mode:** Enable agents to iteratively generate a series of thoughts before producing a final answer. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab))
 *   **Automations:** Record and replay desktop actions (mouse and keyboard sequences). (Details: [Application Tabs - Automations](docs/app_tabs.md#automations-tab))
 *   **Task Scheduling:** Schedule prompts for agents to run at specific times, with optional repetition and OS scheduler integration. (Details: [Application Tabs - Tasks](docs/app_tabs.md#tasks-tab))
+*   **Task Progress Indicators:** View elapsed time and an ETA for scheduled tasks.
 *   **Workflow Builder:** Design and execute reusable, multi-agent workflows. (Details: [Application Tabs - Workflows](docs/app_tabs.md#workflows-tab))
 * **Chat Management:** Save, export, clear, and search chat history. Messages include avatars, colored names and timestamps grouped by date. Use the chat menu to search saved history. Long conversations are automatically summarized. (Details: [Application Tabs - Chat](docs/app_tabs.md#chat-tab))
 *   **Desktop History:** Allow agents to receive periodic screenshots of your desktop for visual context. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab))

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -96,6 +96,8 @@ Schedule prompts to run later. Dates with tasks show a red dot in the calendar.
 - **Filters** – filter by agent or status.
 - **Row Actions** – each row includes Edit, Delete and Complete buttons.
 - **Progress Bar** – indicates how close the task is to its due time.
+- **Elapsed Time** – shows how long the task has existed.
+- **ETA** – estimated time until the due time is reached.
 - **Repeat Interval** – optional minutes after which the task repeats.
 - **Time Format** – ISO 8601 or `YYYY-MM-DD HH:MM:SS` local time.
 

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -18,6 +18,7 @@ from PyQt5.QtWidgets import (
     QComboBox,
 )
 from PyQt5.QtCore import Qt, QDate, QDateTime, QMimeData, QRect
+from datetime import timedelta
 from PyQt5.QtGui import QDrag, QTextCharFormat, QBrush, QColor
 from dialogs import TaskDialog
 from tasks import (
@@ -27,6 +28,7 @@ from tasks import (
     set_task_status,
     update_task_due_time,
     compute_task_progress,
+    compute_task_times,
 )
 
 
@@ -239,6 +241,12 @@ class TasksTab(QWidget):
         bar.setValue(progress)
         bar.setFixedWidth(100)
         layout.addWidget(bar)
+
+        elapsed, remaining = compute_task_times(task)
+        elapsed_label = QLabel(f"Elapsed: {timedelta(seconds=elapsed)}")
+        remaining_label = QLabel(f"ETA: {timedelta(seconds=remaining)}")
+        layout.addWidget(elapsed_label)
+        layout.addWidget(remaining_label)
 
         edit_btn = QPushButton("Edit")
         edit_btn.setProperty("task_id", task["id"])

--- a/tasks.py
+++ b/tasks.py
@@ -256,3 +256,30 @@ def compute_task_progress(task, now=None):
     elapsed = (now - created_dt).total_seconds()
     percent = int(max(0, min(100, (elapsed / total) * 100)))
     return percent
+
+
+def compute_task_times(task, now=None):
+    """Return elapsed and remaining seconds for a task."""
+    now = now or datetime.utcnow()
+    due_str = task.get("due_time", "")
+    created_str = task.get("created_time", "")
+    try:
+        due_dt = (
+            datetime.fromisoformat(due_str)
+            if "T" in due_str
+            else datetime.strptime(due_str, "%Y-%m-%d %H:%M:%S")
+        )
+    except Exception:
+        return 0, 0
+    try:
+        created_dt = (
+            datetime.fromisoformat(created_str)
+            if "T" in created_str
+            else datetime.strptime(created_str, "%Y-%m-%d %H:%M:%S")
+        )
+    except Exception:
+        created_dt = now
+
+    elapsed = max(0, int((now - created_dt).total_seconds()))
+    remaining = max(0, int((due_dt - now).total_seconds()))
+    return elapsed, remaining

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -113,3 +113,14 @@ def test_compute_task_progress():
     now = datetime.strptime("2024-01-01 11:00:00", "%Y-%m-%d %H:%M:%S")
     pct = tasks.compute_task_progress(task, now)
     assert pct == 50
+
+
+def test_compute_task_times():
+    task = {
+        "due_time": "2024-01-01 12:00:00",
+        "created_time": "2024-01-01 10:00:00",
+    }
+    now = datetime.strptime("2024-01-01 11:00:00", "%Y-%m-%d %H:%M:%S")
+    elapsed, remaining = tasks.compute_task_times(task, now)
+    assert elapsed == 3600
+    assert remaining == 3600


### PR DESCRIPTION
## Summary
- show elapsed and remaining time for tasks
- compute elapsed and remaining seconds per task
- document new task progress indicators
- test compute_task_times helper

## Testing
- `flake8 . | head -n 5`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450a7531b08326ab8d72648cb0757f