### PR TITLE
Update task UI terminology

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -167,23 +167,23 @@ class TaskDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
-        # Agent
-        layout.addWidget(QLabel("Agent:"))
+        # Assignee
+        layout.addWidget(QLabel("Assignee:"))
         self.agent_selector = QComboBox()
         self.agent_selector.addItems(self.agents_data.keys())
         self.agent_selector.setCurrentText(agent_name)
-        self.agent_selector.setToolTip("Select the agent for this task.")
+        self.agent_selector.setToolTip("Select the assignee for this task.")
         layout.addWidget(self.agent_selector)
 
-        # Prompt
-        layout.addWidget(QLabel("Prompt:"))
+        # Task Description
+        layout.addWidget(QLabel("Task Description:"))
         self.prompt_edit = QTextEdit()
         self.prompt_edit.setPlainText(prompt)
-        self.prompt_edit.setToolTip("Enter the prompt for the task.")
+        self.prompt_edit.setToolTip("Enter the task description or instructions.")
         layout.addWidget(self.prompt_edit)
 
-        # Due Time
-        layout.addWidget(QLabel("Due Time:"))
+        # Due Date
+        layout.addWidget(QLabel("Due Date:"))
         self.due_time_edit = QDateTimeEdit()
         if due_time:
             try:
@@ -210,12 +210,12 @@ class TaskDialog(QDialog):
         else:
             self.due_time_edit.setDateTime(QDateTime.currentDateTime().addSecs(60))
 
-        self.due_time_edit.setToolTip("Select the due time for the task.")
+        self.due_time_edit.setToolTip("Select the due date and time for the task.")
         self.due_time_edit.setCalendarPopup(True)  # Enable calendar popup
         layout.addWidget(self.due_time_edit)
 
         # Repeat Interval
-        layout.addWidget(QLabel("Repeat Interval (min):"))
+        layout.addWidget(QLabel("Repeat Interval (minutes):"))
         self.repeat_spin = QSpinBox()
         self.repeat_spin.setMinimum(0)
         self.repeat_spin.setMaximum(525600)  # up to a year

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -106,13 +106,15 @@ class TasksTab(QWidget):
         # Filter controls
         filter_layout = QHBoxLayout()
         self.agent_filter = QComboBox()
-        self.agent_filter.addItem("All Agents")
+        self.agent_filter.setToolTip("Filter tasks by assignee")
+        self.agent_filter.addItem("All Assignees")
         for name in getattr(self.parent_app, "agents_data", {}).keys():
             self.agent_filter.addItem(name)
         self.agent_filter.currentIndexChanged.connect(self.refresh_tasks_list)
         filter_layout.addWidget(self.agent_filter)
 
         self.status_filter = QComboBox()
+        self.status_filter.setToolTip("Filter tasks by status")
         self.status_filter.addItems(["All Statuses", "pending", "completed"])
         self.status_filter.currentIndexChanged.connect(self.refresh_tasks_list)
         filter_layout.addWidget(self.status_filter)
@@ -195,7 +197,7 @@ class TasksTab(QWidget):
         status_filter = self.status_filter.currentText()
         filtered = []
         for task in self.tasks:
-            if agent_filter != "All Agents" and task.get("agent_name") != agent_filter:
+            if agent_filter != "All Assignees" and task.get("agent_name") != agent_filter:
                 continue
             if status_filter != "All Statuses" and task.get("status", "pending") != status_filter:
                 continue
@@ -231,6 +233,7 @@ class TasksTab(QWidget):
         repeat_str = f" every {repeat}m" if repeat else ""
         summary = f"[{due_time}] {agent_name}{repeat_str} ({status}) - {prompt[:30]}..."
         label = QLabel(summary)
+        label.setToolTip(f"Assignee: {agent_name}\nStatus: {status}\nDue: {due_time}")
         layout.addWidget(label)
 
         progress = compute_task_progress(task)

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -40,7 +40,7 @@ def test_filters_and_row_actions():
     assert tab.tasks_list.count() == 1
 
     tab.status_filter.setCurrentText("completed")
-    tab.agent_filter.setCurrentText("All Agents")
+    tab.agent_filter.setCurrentText("All Assignees")
     tab.refresh_tasks_list()
     assert tab.tasks_list.count() == 1
 


### PR DESCRIPTION
## Summary
- use standard task management terminology in Tasks tab
- add tooltips for filter controls
- adjust dialog labels to use common terms
- update related tests

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450a8a31ac83268ccf6fd3cd3a7c72