### PR TITLE
Improve task creation validation

### DIFF
--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -90,6 +90,7 @@ Record and play back desktop actions.
 
 Schedule prompts to run later. Dates with tasks show a red dot in the calendar.
 - **Add Task** – create a prompt for a specific agent. Defaults to one minute from now.
+- **Required Fields** – Task dialog marks required fields with * and the save button stays disabled until they are filled.
 - **Edit** – change an existing task.
 - **Delete** – remove a task after confirmation.
 - **Toggle Status** – mark a task as completed or pending.

--- a/tests/test_task_dialog.py
+++ b/tests/test_task_dialog.py
@@ -1,0 +1,34 @@
+import os
+from PyQt5.QtWidgets import QApplication, QWidget
+import dialogs
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class DummyParent(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.agents_data = {"agent1": {}}
+
+
+def test_ok_button_disabled_until_fields_complete():
+    app = QApplication.instance() or QApplication([])
+    parent = DummyParent()
+    dlg = dialogs.TaskDialog(parent, {"agent1": {}})
+    dlg.prompt_edit.clear()
+    dlg.validate_fields()
+    assert not dlg.ok_button.isEnabled()
+    dlg.prompt_edit.setPlainText("Do something")
+    dlg.validate_fields()
+    assert dlg.ok_button.isEnabled()
+    app.quit()
+
+
+def test_focus_on_first_missing_field():
+    app = QApplication.instance() or QApplication([])
+    parent = DummyParent()
+    dlg = dialogs.TaskDialog(parent, {"agent1": {}})
+    dlg.prompt_edit.clear()
+    dlg.accept()
+    assert dlg.prompt_edit.styleSheet() != ""
+    app.quit()


### PR DESCRIPTION
## Summary
- mark required fields in the task dialog
- disable the Save button until fields are complete
- focus on the first missing field when saving
- document required field behavior
- test the new validation logic

## Testing
- `flake8 .` *(fails: many style issues)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450ae73168832695905a755df6d199