### PR TITLE
Add task failure details display

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Cerebro offers a rich set of features to enhance your interaction with AI models
 *   **Automations:** Record and replay desktop actions (mouse and keyboard sequences). (Details: [Application Tabs - Automations](docs/app_tabs.md#automations-tab))
 * **Task Scheduling:** Schedule prompts for agents to run at specific times, with optional repetition, drag-and-drop reordering, duplication, undo after deletion, inline editing, and bulk editing. (Details: [Application Tabs - Tasks](docs/app_tabs.md#tasks-tab))
 * * **Task Progress Indicators:** View elapsed time and an ETA for scheduled tasks.
+*   **Failure Details:** When tasks fail or are put on hold the reason, a link to more information, and suggested actions appear in the task list.
 *   **Workflow Builder:** Design and execute reusable, multi-agent workflows. (Details: [Application Tabs - Workflows](docs/app_tabs.md#workflows-tab))
 * **Chat Management:** Save, export, clear, and search chat history. Messages include avatars, colored names and timestamps grouped by date. Use the chat menu to search saved history. Long conversations are automatically summarized. (Details: [Application Tabs - Chat](docs/app_tabs.md#chat-tab))
 *   **Desktop History:** Allow agents to receive periodic screenshots of your desktop for visual context. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab))

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -101,6 +101,7 @@ Schedule prompts to run later. Dates with tasks show a red dot in the calendar.
 - **Drag and Drop** – reorder tasks by dragging them up or down.
 - **Undo Toast** – after deleting a task a popup allows you to undo.
 - **Context Menu** – right-click a task in any view to Edit, Delete or change its status.
+- **Failure Reasons** – if a task fails or is put on hold, the reason is displayed under the task summary with a link to more information and suggested actions when available.
 ## How It Was Resolved
 - **Progress Bar** – indicates how close the task is to its due time.
 - **Elapsed Time** – shows how long the task has existed.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -31,6 +31,7 @@ Cerebro is a multi-agent AI application with a rich set of features:
 - **Agent Management:** Configure multiple AI agents with different models, roles (Coordinator, Assistant, Specialist), and capabilities.
 - **Tool Integration:** Extend agent capabilities with custom tools.
 - **Task Automation:** Record desktop automations and schedule tasks for agents with inline editing, bulk changes, drag-and-drop reordering, duplication, and undo for deleted tasks.
+- **Failure Details:** When a task cannot run, the task entry shows the reason along with a link to more information and any suggested actions.
 Reasoning for this resolution:
 - **Workflows:** Define complex, multi-agent workflows.
 - **Customization:** Personalize the UI with themes, colors, and more.

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -367,9 +367,32 @@ class TasksTab(QWidget):
         layout.addWidget(due_edit)
 
         summary_label = QLabel(f"{prompt[:30]}...{repeat_str} ({status})")
-        # Added tooltip from 'main' branch for more context on hover
-        summary_label.setToolTip(f"Assignee: {agent_name}\nStatus: {status}\nDue: {due_time}")
+        tooltip = f"Assignee: {agent_name}\nStatus: {status}\nDue: {due_time}"
+        reason = task.get("status_reason", "")
+        action_hint = task.get("action_hint", "")
+        link = task.get("error_link", "")
+        if reason:
+            tooltip += f"\nReason: {reason}"
+        if action_hint:
+            tooltip += f"\nAction: {action_hint}"
+        summary_label.setToolTip(tooltip)
         layout.addWidget(summary_label)
+
+        if reason and status in ("failed", "on_hold"):
+            reason_label = QLabel(reason)
+            color = "#f44336" if status == "failed" else "#9e9e9e"
+            reason_label.setStyleSheet(f"color: {color}; font-weight: bold;")
+            reason_label.setWordWrap(True)
+            layout.addWidget(reason_label)
+            if action_hint:
+                hint_label = QLabel(action_hint)
+                hint_label.setStyleSheet("font-style: italic;")
+                hint_label.setWordWrap(True)
+                layout.addWidget(hint_label)
+            if link:
+                link_label = QLabel(f'<a href="{link}">More Info</a>')
+                link_label.setOpenExternalLinks(True)
+                layout.addWidget(link_label)
 
         style = STATUS_STYLES.get(status, {"color": "black", "icon": QStyle.SP_FileIcon})
         status_layout = QHBoxLayout()
@@ -580,7 +603,8 @@ class TasksTab(QWidget):
                 self.parent_app.refresh_metrics_display()
             self.refresh_tasks_list()
 
-def inline_set_agent(self, task_id, agent_name):
+
+    def inline_set_agent(self, task_id, agent_name):
         """Inline update of the task's agent."""
         update_task_agent(
             self.tasks, task_id, agent_name, debug_enabled=self.parent_app.debug_enabled

--- a/tasks.py
+++ b/tasks.py
@@ -233,12 +233,26 @@ def duplicate_task(tasks, task_id, debug_enabled=False, os_schedule=False):
         _schedule_os_task(new_task["id"], new_task.get("due_time", ""), debug_enabled)
     return new_task["id"]
 
-def set_task_status(tasks, task_id, status, debug_enabled=False):
-    """Set the status of a task."""
+def set_task_status(
+    tasks,
+    task_id,
+    status,
+    reason=None,
+    action_hint=None,
+    error_link=None,
+    debug_enabled=False,
+):
+    """Set the status of a task and optional failure details."""
     task = next((t for t in tasks if t["id"] == task_id), None)
     if not task:
         return f"[Task Error] Task '{task_id}' not found."
     task["status"] = status
+    if reason is not None:
+        task["status_reason"] = reason
+    if action_hint is not None:
+        task["action_hint"] = action_hint
+    if error_link is not None:
+        task["error_link"] = error_link
     save_tasks(tasks, debug_enabled)
     if debug_enabled:
         print(f"[Debug] Set task {task_id} status to '{status}'")

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -58,7 +58,7 @@ def test_filters_and_row_actions():
     bars = item_widget.findChildren(QProgressBar)
     assert len(bars) == 1
     assert 0 <= bars[0].value() <= 100
-combos = item_widget.findChildren(QComboBox)
+    combos = item_widget.findChildren(QComboBox)
     edits = item_widget.findChildren(QDateTimeEdit)
     assert combos and edits
     assert tab.tasks_list.selectionMode() == tab_tasks.QAbstractItemView.ExtendedSelection
@@ -113,4 +113,31 @@ def test_context_menu(monkeypatch):
 
     assert "Edit" in captured and "Delete" in captured
     assert any(t in captured for t in ["Mark Completed", "Mark Pending"])
+    app.quit()
+
+
+def test_failed_reason_display():
+    app = QApplication.instance() or QApplication([])
+    dummy = DummyApp()
+    dummy.agents_data = {"a1": {}}
+    dummy.tasks = [
+        {
+            "id": "1",
+            "agent_name": "a1",
+            "prompt": "p",
+            "due_time": "2024-01-01",
+            "status": "failed",
+            "status_reason": "Agent offline",
+            "action_hint": "Start the agent",
+            "error_link": "http://example.com",
+            "repeat_interval": 0,
+        }
+    ]
+    tab = tab_tasks.TasksTab(dummy)
+    tab.refresh_tasks_list()
+    item_widget = tab.tasks_list.itemWidget(tab.tasks_list.item(0))
+    texts = [w.text() for w in item_widget.findChildren(QLabel)]
+    assert "Agent offline" in texts
+    assert "Start the agent" in texts
+    assert any("More Info" in t for t in texts)
     app.quit()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -77,9 +77,20 @@ def test_set_task_status(monkeypatch):
     task_list = []
     monkeypatch.setattr(tasks, "save_tasks", noop_save)
     task_id = tasks.add_task(task_list, "agent1", "do work", "2024-01-01 10:00")
-    err = tasks.set_task_status(task_list, task_id, "completed")
+    err = tasks.set_task_status(
+        task_list,
+        task_id,
+        "completed",
+        reason="done",
+        action_hint="restart",
+        error_link="http://example.com",
+    )
     assert err is None
-    assert task_list[0]["status"] == "completed"
+    task = task_list[0]
+    assert task["status"] == "completed"
+    assert task["status_reason"] == "done"
+    assert task["action_hint"] == "restart"
+    assert task["error_link"] == "http://example.com"
 
 
 def test_set_task_status_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- allow set_task_status to store reason, action hints and a link
- show task failure details in the Tasks tab
- document failure display in README and user guide
- test new functionality

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684515600d988326bb280fbd1e5b5d67