### PR TITLE
Enhance tools UI with status indicators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E265,E402,W293,E302,E501

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Cerebro offers a rich set of features to enhance your interaction with AI models
 
 *   **Multiple AI Agents:** Create and manage multiple AI agents, each with its own model, system prompt, role (Coordinator, Assistant, Specialist), and appearance. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab), [Configuration - agents.json](docs/configuration.md#agentsjson))
 *   **Tool Integration:** Grant agents the ability to use tools (Python scripts) to perform actions and retrieve information. Tools can be bundled, custom-developed, or installed as plugins. (Details: [Plugins and Tools](docs/plugins.md), [Application Tabs - Tools](docs/app_tabs.md#tools-tab))
+*   **Tool Status Indicators:** The Tools tab now shows a status column with color-coded icons so you can easily see if a tool is enabled or disabled.
 *   **Thinking Mode:** Enable agents to iteratively generate a series of thoughts before producing a final answer. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab))
 *   **Automations:** Record and replay desktop actions (mouse and keyboard sequences). (Details: [Application Tabs - Automations](docs/app_tabs.md#automations-tab))
 * **Task Scheduling:** Schedule prompts for agents to run at specific times, with optional repetition, drag-and-drop reordering, duplication, undo after deletion, inline editing, and bulk editing. (Details: [Application Tabs - Tasks](docs/app_tabs.md#tasks-tab))

--- a/docs/app_tabs.md
+++ b/docs/app_tabs.md
@@ -52,6 +52,7 @@ Manage scripts that agents can invoke.
 3. **Delete** – remove a tool.
 4. **Run** – execute a tool manually with JSON arguments.
    The editor supports syntax highlighting when QScintilla is installed.
+5. **Status Column** – displays whether each tool is enabled or disabled with a color-coded icon. Disabled tools appear greyed out.
 
 Bundled plugins include:
 - **file-summarizer** – summarize text files.

--- a/tab_tasks.py
+++ b/tab_tasks.py
@@ -580,12 +580,14 @@ class TasksTab(QWidget):
                 self.parent_app.refresh_metrics_display()
             self.refresh_tasks_list()
 
-def inline_set_agent(self, task_id, agent_name):
+
+    def inline_set_agent(self, task_id, agent_name):
         """Inline update of the task's agent."""
         update_task_agent(
             self.tasks, task_id, agent_name, debug_enabled=self.parent_app.debug_enabled
         )
         self.refresh_tasks_list()
+
 
     def inline_set_due(self, task_id, qdatetime):
         """Inline update of the task's due time."""
@@ -594,6 +596,7 @@ def inline_set_agent(self, task_id, agent_name):
             self.tasks, task_id, due_str, debug_enabled=self.parent_app.debug_enabled
         )
         self.refresh_tasks_list()
+
 
     def bulk_edit_ui(self):
         """Edit multiple selected tasks at once."""

--- a/tab_tools.py
+++ b/tab_tools.py
@@ -1,13 +1,32 @@
 #tab_tools.py
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QListWidget, QHBoxLayout, QPushButton, QListWidgetItem,
-    QLabel, QMessageBox, QDialog, QStyle, QAbstractItemView, QInputDialog,
-    QLineEdit
+    QWidget,
+    QVBoxLayout,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QHBoxLayout,
+    QPushButton,
+    QLabel,
+    QMessageBox,
+    QDialog,
+    QStyle,
+    QAbstractItemView,
+    QInputDialog,
+    QLineEdit,
 )
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor
 from dialogs import ToolDialog
-from tools import add_tool, edit_tool, delete_tool, run_tool
+from tools import add_tool, edit_tool, delete_tool, run_tool, get_available_plugins
 import json
+
+# Mapping of status text to display color and icon
+TOOL_STATUS_STYLES = {
+    "Enabled": {"color": "#4caf50", "icon": QStyle.SP_DialogApplyButton},
+    "Disabled": {"color": "#9e9e9e", "icon": QStyle.SP_DialogCancelButton},
+    "Error": {"color": "#f44336", "icon": QStyle.SP_MessageBoxCritical},
+    "Needs Configuration": {"color": "#ff9800", "icon": QStyle.SP_MessageBoxWarning},
+}
 
 
 class ToolsTab(QWidget):
@@ -23,9 +42,10 @@ class ToolsTab(QWidget):
         self.setLayout(self.layout)
 
         # Tools List
-        self.tools_list = QListWidget()
-        self.tools_list.setSelectionMode(QAbstractItemView.SingleSelection)  # Enforce single selection
-        self.tools_list.itemSelectionChanged.connect(self.on_item_selection_changed) # Connect selection change
+        self.tools_list = QTreeWidget()
+        self.tools_list.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.tools_list.setHeaderLabels(["Name", "Description", "Status"])
+        self.tools_list.itemSelectionChanged.connect(self.on_item_selection_changed)
         self.layout.addWidget(self.tools_list)
 
         # Label shown when no tools are present
@@ -91,17 +111,35 @@ class ToolsTab(QWidget):
         self.delete_button.setEnabled(False)
         self.run_button.setEnabled(False)
 
-        if not self.tools:
+        builtins = [t for t in self.tools if 'plugin_module' not in t]
+        plugins = get_available_plugins(self.parent_app.debug_enabled)
+
+        if not builtins and not plugins:
             self.no_tools_label.show()
             return
 
-        for tool in self.tools:
-            item = QListWidgetItem(f"{tool['name']}: {tool['description']}")
-            item.setData(Qt.UserRole, tool['name'])
-            item.setData(Qt.UserRole + 1, 'plugin_module' in tool)
-            if 'plugin_module' in tool:
-                item.setFlags(item.flags() & ~Qt.ItemIsEditable)
-            self.tools_list.addItem(item)
+        for tool in builtins:
+            item = QTreeWidgetItem([tool['name'], tool['description'], 'Enabled'])
+            item.setData(0, Qt.UserRole, tool['name'])
+            item.setData(0, Qt.UserRole + 1, False)
+            style = TOOL_STATUS_STYLES['Enabled']
+            icon = self.style().standardIcon(style['icon'])
+            item.setIcon(2, icon)
+            self.tools_list.addTopLevelItem(item)
+
+        for plug in plugins:
+            status_text = 'Enabled' if plug.get('enabled') else 'Disabled'
+            item = QTreeWidgetItem([plug['name'], plug['description'], status_text])
+            item.setData(0, Qt.UserRole, plug['name'])
+            item.setData(0, Qt.UserRole + 1, True)
+            style = TOOL_STATUS_STYLES[status_text]
+            icon = self.style().standardIcon(style['icon'])
+            item.setIcon(2, icon)
+            if not plug.get('enabled'):
+                for i in range(3):
+                    item.setForeground(i, QColor('gray'))
+                item.setFlags(item.flags() & ~Qt.ItemIsEnabled & ~Qt.ItemIsSelectable)
+            self.tools_list.addTopLevelItem(item)
 
     def add_tool_ui(self):
         dialog = ToolDialog(title="Add Tool")

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -58,7 +58,7 @@ def test_filters_and_row_actions():
     bars = item_widget.findChildren(QProgressBar)
     assert len(bars) == 1
     assert 0 <= bars[0].value() <= 100
-combos = item_widget.findChildren(QComboBox)
+    combos = item_widget.findChildren(QComboBox)
     edits = item_widget.findChildren(QDateTimeEdit)
     assert combos and edits
     assert tab.tasks_list.selectionMode() == tab_tasks.QAbstractItemView.ExtendedSelection

--- a/tests/test_tab_tools.py
+++ b/tests/test_tab_tools.py
@@ -1,0 +1,47 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QApplication
+import tab_tools
+
+
+class DummyApp:
+    def __init__(self):
+        self.debug_enabled = False
+        self.tools = [
+            {
+                "name": "demo",
+                "description": "Demo",
+                "plugin_module": object(),
+                "script": "",
+                "script_path": ""
+            }
+        ]
+
+    def refresh_tools_list(self):
+        pass
+
+
+def test_status_column(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+
+    monkeypatch.setattr(
+        tab_tools,
+        "get_available_plugins",
+        lambda debug=False: [
+            {"name": "demo", "description": "Demo", "enabled": True, "path": ""},
+            {"name": "other", "description": "Other", "enabled": False, "path": ""},
+        ],
+    )
+
+    tab = tab_tools.ToolsTab(DummyApp())
+    tab.refresh_tools_list()
+
+    assert tab.tools_list.topLevelItemCount() == 2
+    enabled_item = tab.tools_list.topLevelItem(0)
+    disabled_item = tab.tools_list.topLevelItem(1)
+
+    assert enabled_item.text(2) == "Enabled"
+    assert disabled_item.text(2) == "Disabled"
+    assert not (disabled_item.flags() & tab_tools.Qt.ItemIsEnabled)
+    app.quit()


### PR DESCRIPTION
## Summary
- show a status column in the Tools tab with color-coded icons
- grey out disabled tools
- document status column in README and app docs
- add tests for the new Tools tab behaviour
- add flake8 config for repo

## Testing
- `flake8 tab_tools.py tests/test_tab_tools.py tests/test_tab_tasks.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684515a2ec908326a0f4bca80d1ba947