### PR TITLE
Fix chat routing restriction

### DIFF
--- a/message_broker.py
+++ b/message_broker.py
@@ -125,10 +125,6 @@ class MessageBroker:
             self.app.chat_tab.append_message_html(error_msg)
             return
 
-        # Only allow users to send messages to the Director agent
-        if sender == "user" and recipient != "Director":
-            return
-
         # Role-based checks
         # If a Specialist, only allow messages from Coordinator.
         if agent_settings.get('role') == 'Specialist' and sender != 'Coordinator':

--- a/tests/test_tab_tasks.py
+++ b/tests/test_tab_tasks.py
@@ -58,7 +58,7 @@ def test_filters_and_row_actions():
     bars = item_widget.findChildren(QProgressBar)
     assert len(bars) == 1
     assert 0 <= bars[0].value() <= 100
-combos = item_widget.findChildren(QComboBox)
+    combos = item_widget.findChildren(QComboBox)
     edits = item_widget.findChildren(QDateTimeEdit)
     assert combos and edits
     assert tab.tasks_list.selectionMode() == tab_tasks.QAbstractItemView.ExtendedSelection


### PR DESCRIPTION
## Summary
- allow sending messages to any enabled agent
- fix indentation in `tests/test_tab_tasks.py`

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684518d28f0c83269d566716d2eeca81