### PR TITLE
Fix: Update default agent model to devstral:latest

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -1,6 +1,6 @@
 {
   "Default Agent": {
-    "model": "llama3.2-vision",
+    "model": "devstral:latest",
     "temperature": 0.7,
     "max_tokens": 512,
     "system_prompt": "You are the Cerebro default assistant with full tool access. Use tools whenever they help and keep replies concise.",


### PR DESCRIPTION
The Default Agent in agents.json was configured to use "llama3.2-vision", which was causing a 500 error because you had "devstral:latest" installed instead.

This change updates the "model" field for the "Default Agent" to "devstral:latest" to match the available model.