### PR TITLE
Add back button for agent editing

### DIFF
--- a/app.py
+++ b/app.py
@@ -348,6 +348,13 @@ class AIChatApp(QMainWindow):
         
     def change_tab(self, index, button=None):
         """Change the active tab and update button styles."""
+        # Revert unsaved agent changes when leaving the edit screen
+        if (
+            self.content_stack.currentIndex() == 1
+            and self.agents_tab.stacked.currentWidget() == self.agents_tab.edit_page
+        ):
+            self.agents_tab.show_agent_list()
+
         self.content_stack.setCurrentIndex(index)
 
         if index == 1 and not self.agents_onboarding_complete:

--- a/tab_agents.py
+++ b/tab_agents.py
@@ -74,8 +74,8 @@ class AgentsTab(QWidget):
         edit_layout = QVBoxLayout(self.edit_page)
 
         nav_layout = QHBoxLayout()
-        self.cancel_button = QPushButton("Cancel")
-        self.cancel_button.clicked.connect(self.show_agent_list)
+        self.back_button = QPushButton("Back")
+        self.back_button.clicked.connect(self.show_agent_list)
         self.save_button = QPushButton("Save")
         self.save_button.clicked.connect(self.on_save_agent_clicked)
         self.delete_button = QPushButton("Delete")
@@ -88,7 +88,7 @@ class AgentsTab(QWidget):
 
         nav_layout.addStretch()
         nav_layout.addWidget(help_btn_edit)
-        nav_layout.addWidget(self.cancel_button)
+        nav_layout.addWidget(self.back_button)
         nav_layout.addWidget(self.save_button)
         nav_layout.addWidget(self.delete_button)
 

--- a/tests/test_agents_navigation.py
+++ b/tests/test_agents_navigation.py
@@ -1,0 +1,44 @@
+import os
+from PyQt5.QtWidgets import QApplication, QPushButton
+import tab_agents
+import app as app_module
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyApp:
+    def __init__(self):
+        self.agents_data = {"agent": {"color": "#000000"}}
+        self.tools = []
+        self.automations = []
+        self.tasks = []
+        self.debug_enabled = False
+    def add_agent(self):
+        pass
+    def save_agents(self):
+        pass
+    def update_send_button_state(self):
+        pass
+    def delete_agent(self, name):
+        pass
+
+
+def test_back_button_exists():
+    app = QApplication.instance() or QApplication([])
+    tab = tab_agents.AgentsTab(DummyApp())
+    tab.edit_agent("agent")
+    buttons = [b for b in tab.findChildren(QPushButton) if b.text() == "Back"]
+    assert buttons
+    app.quit()
+
+
+def test_change_tab_trashes_unsaved(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    window = app_module.AIChatApp()
+    window.agents_data = {"agent": {"color": "#000000"}}
+    window.content_stack.setCurrentIndex(1)
+    window.agents_tab.edit_agent("agent")
+    window.agents_data["agent"]["color"] = "#FFFFFF"
+    window.agents_tab.unsaved_changes = True
+    window.change_tab(0)
+    assert window.agents_data["agent"]["color"] == "#000000"
+    app.quit()


### PR DESCRIPTION
## Summary
- show a Back button while editing agents
- reset agent form when navigating away
- test back button behavior

## Testing
- `flake8 tab_agents.py app.py tests/test_agents_navigation.py | head -n 5`
- `PYTHONPATH=. pytest tests/test_agents_navigation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68452762531083269cc6ad74b41797b6