### PR TITLE
Fix missing logger import

### DIFF
--- a/log_utils.py
+++ b/log_utils.py
@@ -1,16 +1,20 @@
 import os
 import logging
 
+logger = logging.getLogger("cerebro")
+
 LOG_FILE = os.path.join(os.path.dirname(__file__), "cerebro.log")
 
 
 def setup_logging(debug_enabled: bool = False) -> None:
     """Configure application logging."""
+    level = logging.DEBUG if debug_enabled else logging.INFO
     logging.basicConfig(
         filename=LOG_FILE,
-        level=logging.DEBUG if debug_enabled else logging.INFO,
+        level=level,
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
+    logger.setLevel(level)
 
 
 def get_log_file_path() -> str:


### PR DESCRIPTION
## Summary
- provide a `logger` instance in `log_utils`

## Testing
- `flake8 log_utils.py automation_sequences.py tests/test_automation_sequences_step_based.py`
- `pytest tests/test_automation_sequences_step_based.py::TestStepBasedSaveLoad::test_load_step_automations_json_error -q`
- `pytest tests/test_log_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684593c394dc8326aa22f2508ae50d15