### PR TITLE
I fixed a RuntimeError in the Automations tab and addressed some layo…

### DIFF
--- a/tab_automations.py
+++ b/tab_automations.py
@@ -133,11 +133,9 @@ class AutomationsTab(QWidget):
 
     def _setup_step_based_automations_ui(self):
         """Sets up the UI for the Step-based Automations sub-tab."""
-        step_tab_layout = QHBoxLayout(self.step_automations_tab)
-
         # Use QSplitter for resizable panels
         splitter = QSplitter(Qt.Horizontal)
-        step_tab_layout.addWidget(splitter)
+        # step_tab_layout was removed, splitter will be added to main_step_layout_container later
 
         # Left Panel: Available Steps
         left_panel = QWidget()
@@ -191,9 +189,9 @@ class AutomationsTab(QWidget):
         # Right Panel: Step Parameters
         # right_panel = QWidget() # QGroupBox is already a QWidget
         self.step_parameter_editor_area = QGroupBox("Step Parameters")
-        self.param_form_layout = QFormLayout(self.step_parameter_editor_area) # Use QFormLayout
+        self.param_form_layout = QFormLayout() # Initialize without parent
 
-        self.placeholder_param_label = QLabel("Select a step from the sequence to edit its parameters.")
+        self.placeholder_param_label = QLabel("Select a step from the sequence to edit its parameters.", parent=self.step_parameter_editor_area)
         self.placeholder_param_label.setAlignment(Qt.AlignCenter)
         self.placeholder_param_label.setWordWrap(True)
         # Add placeholder to the layout, it will be hidden/shown as needed
@@ -215,8 +213,8 @@ class AutomationsTab(QWidget):
 
         # Bottom Buttons for Step Automations
         step_bottom_btn_layout = QHBoxLayout()
-        main_step_layout_container = QVBoxLayout()
-        main_step_layout_container.addWidget(splitter)
+        main_step_layout_container = QVBoxLayout() # This will be the main layout for step_automations_tab
+        main_step_layout_container.addWidget(splitter) # Add splitter here
         main_step_layout_container.addLayout(step_bottom_btn_layout)
         self.step_automations_tab.setLayout(main_step_layout_container)
 


### PR DESCRIPTION
…ut warnings for you.

The main fix addresses a RuntimeError that occurred when you cleared the parameter editor in the step-based automations UI. It seems the `placeholder_param_label` was being deleted when its row was removed from the QFormLayout, and then an attempt was made to re-add the deleted C++ object, which caused a crash.
I resolved this by explicitly setting the parent of `placeholder_param_label` to its QGroupBox container (`self.step_parameter_editor_area`) during initialization in `_setup_step_based_automations_ui`. This ensures the label widget persists even when removed from the layout's management and can be safely re-added.

Additionally, I corrected the setup of layouts in
`_setup_step_based_automations_ui` to prevent
`QWidget::setLayout` and `QLayout::addChildLayout` warnings. This involved:
- Initializing `self.param_form_layout` without a direct parent and adding it to an intermediate QVBoxLayout, which is then set as the single layout for `self.step_parameter_editor_area`.
- Removing an initial QHBoxLayout set on `self.step_automations_tab` and ensuring its main layout container is set only once.