### PR TITLE
Fix Automations tab RuntimeError

### DIFF
--- a/tab_automations.py
+++ b/tab_automations.py
@@ -445,12 +445,22 @@ class AutomationsTab(QWidget):
         """Clears the parameter editor and shows the placeholder."""
         # Remove all widgets from the form layout except the placeholder
         while self.param_form_layout.rowCount() > 0:
-            self.param_form_layout.removeRow(0)
+            row = self.param_form_layout.takeRow(0)
+            if row.labelItem:
+                widget = row.labelItem.widget()
+                if widget is not None:
+                    widget.setParent(None)
+            if row.fieldItem:
+                widget = row.fieldItem.widget()
+                if widget is not None:
+                    widget.setParent(None)
 
         # Add the placeholder back if it's not already there (it might be if it was the only thing)
         # A bit of a hacky way to ensure it's the only thing
-        if self.param_form_layout.rowCount() == 0 :
-             self.param_form_layout.addRow(self.placeholder_param_label)
+        if self.param_form_layout.rowCount() == 0:
+            if self.placeholder_param_label.parent() is None:
+                self.placeholder_param_label.setParent(self.step_parameter_editor_area)
+            self.param_form_layout.addRow(self.placeholder_param_label)
 
         self.placeholder_param_label.setVisible(True)
         self.apply_param_changes_btn.setVisible(False)

--- a/tests/test_automations_tab.py
+++ b/tests/test_automations_tab.py
@@ -1,0 +1,18 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PyQt5.QtWidgets import QApplication
+import tab_automations
+
+class DummyApp:
+    def __init__(self):
+        self.automations = []
+        self.debug_enabled = False
+        self.main_window = None
+
+def test_clear_parameter_editor_safe():
+    app = QApplication.instance() or QApplication([])
+    tab = tab_automations.AutomationsTab(DummyApp())
+    tab._clear_parameter_editor()
+    tab.placeholder_param_label.setText("Placeholder")
+    assert tab.param_form_layout.rowCount() == 1
+    app.quit()


### PR DESCRIPTION
## Summary
- prevent deleting the placeholder label when clearing automation step parameters
- add regression test for parameter editor clearing

## Testing
- `flake8 .` *(fails: F401/Q* etc.)*
- `PYTHONPATH=. pytest -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6845a1e2ca1083269ca4a8f3dc659a70