### PR TITLE
Fix step automation crash

### DIFF
--- a/automation_sequences.py
+++ b/automation_sequences.py
@@ -54,9 +54,15 @@ class AskAgentParams(Dict):
     prompt: str
     screenshot_path: Union[str, None] # Optional
 
+class MouseDragParams(Dict):
+    start_x: int
+    start_y: int
+    end_x: int
+    end_y: int
+
 class LoopStartParams(Dict):
-    count: Union[int, None] # Optional, for count-based loops
-    condition: Union[str, None] # Optional, for condition-based loops
+    count: Union[int, None]  # Optional, for count-based loops
+    condition: Union[str, None]  # Optional, for condition-based loops
 
 # LoopEnd, Else, EndIf typically don't have parameters, but can be empty dicts if needed.
 
@@ -67,14 +73,8 @@ StepParams = Union[
     AskAgentParams,
     LoopStartParams,
     MouseDragParams,
-    Dict[str, Any], # For steps with no specific params like LoopEnd, Else, EndIf
+    Dict[str, Any],  # For steps with no specific params like LoopEnd, Else, EndIf
 ]
-
-class MouseDragParams(Dict):
-    start_x: int
-    start_y: int
-    end_x: int
-    end_y: int
 
 class Step(Dict):
     type: SupportedStepType

--- a/tab_automations.py
+++ b/tab_automations.py
@@ -6,7 +6,8 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtCore import Qt, QSize
-import os # For checking screenshot path
+import os  # For checking screenshot path
+import time
 
 from automation_sequences import (
     create_step, # Import create_step


### PR DESCRIPTION
## Summary
- import `time` in step automations tab
- define `MouseDragParams` before it is used in `automation_sequences`

## Testing
- `flake8 .`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q` *(fails: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6845c2312f848326a932d850dd057a23