### PR TITLE
Add screenshot tempfile capture function

### DIFF
--- a/screenshot.py
+++ b/screenshot.py
@@ -2,9 +2,24 @@
 
 import os
 import base64
+import tempfile
 from datetime import datetime
 from PyQt5.QtCore import QObject, QTimer
 from PyQt5.QtGui import QGuiApplication
+
+
+def capture_screenshot_to_tempfile() -> str:
+    """Capture the primary screen and save it to a temporary PNG file."""
+    screen = QGuiApplication.primaryScreen()
+    if screen is None:
+        raise RuntimeError("No primary screen available")
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    pixmap = screen.grabWindow(0)
+    if not pixmap.save(path, "png"):
+        os.unlink(path)
+        raise RuntimeError("Failed to save screenshot")
+    return path
 
 
 class ScreenshotManager(QObject):

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,3 +1,4 @@
+import os
 import builtins
 from tempfile import TemporaryDirectory
 import screenshot
@@ -23,4 +24,16 @@ def test_capture_base64(monkeypatch):
         assert len(mgr.get_images()) == 2
         mgr.capture()
         assert len(mgr.get_images()) == 2  # respect max_images
+
+
+def test_capture_screenshot_to_tempfile(monkeypatch):
+    """capture_screenshot_to_tempfile should save image to a temporary file."""
+    monkeypatch.setattr(screenshot.QGuiApplication, 'primaryScreen', lambda: FakeScreen())
+    path = screenshot.capture_screenshot_to_tempfile()
+    try:
+        with open(path, 'rb') as f:
+            data = f.read()
+        assert data == b'fake'
+    finally:
+        os.remove(path)
 


### PR DESCRIPTION
## Summary
- capture PyQt5 screen to a temporary file
- test new screenshot helper

## Testing
- `flake8 .`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_6845c3a575f08326a86a9dd86e239051