### PR TITLE
Fix automation ask agent checkbox

### DIFF
--- a/tab_automations.py
+++ b/tab_automations.py
@@ -2,7 +2,8 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QListWidget, QPushButton, QHBoxLayout,
     QListWidgetItem, QLabel, QMessageBox, QInputDialog, QLineEdit, QStyle,
     QTabWidget, QGroupBox, QSplitter, QFormLayout, QSpinBox, QDoubleSpinBox,
-    QComboBox, QTextEdit, QAbstractItemView, QApplication, QDialog, QDialogButtonBox
+    QComboBox, QTextEdit, QAbstractItemView, QApplication, QDialog, QDialogButtonBox,
+    QCheckBox
 )
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtCore import Qt, QSize, QTimer

--- a/tests/test_automations_tab.py
+++ b/tests/test_automations_tab.py
@@ -16,3 +16,21 @@ def test_clear_parameter_editor_safe():
     tab.placeholder_param_label.setText("Placeholder")
     assert tab.param_form_layout.rowCount() == 1
     app.quit()
+
+
+def test_populate_parameter_editor_ask_agent_qcheckbox():
+    app = QApplication.instance() or QApplication([])
+    tab = tab_automations.AutomationsTab(DummyApp())
+    step_data = {
+        "type": tab_automations.STEP_TYPE_ASK_AGENT,
+        "params": {
+            "prompt": "hi",
+            "agent_name": "(No Agent)",
+            "send_screenshot": True,
+        },
+    }
+    tab._populate_parameter_editor(step_data)
+    widget = tab.current_param_widgets.get("send_screenshot")
+    assert isinstance(widget, tab_automations.QCheckBox)
+    assert widget.isChecked()
+    app.quit()


### PR DESCRIPTION
## Summary
- import `QCheckBox` so Ask Agent automation step works
- add regression test for Ask Agent parameter editor

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c64525c8832682fefff25d5b4a81