### PR TITLE
Handle invalid events in automation playback

### DIFF
--- a/automation_sequences.py
+++ b/automation_sequences.py
@@ -165,7 +165,9 @@ def run_automation(automations: List[Dict[str, Any]], name: str,
             pyautogui = _pg
         except Exception:
             return "[Automation Error] pyautogui not installed."
-    events = auto.get("events", [])
+    events = auto.get("events")
+    if not isinstance(events, list):
+        return f"[Automation Error] Invalid event list for '{name}'"
     button_down = None
     for evt in events:
         etype = evt.get("type")

--- a/tests/test_automation_sequences.py
+++ b/tests/test_automation_sequences.py
@@ -156,6 +156,13 @@ def test_run_automation_delay(monkeypatch):
     assert sleeps == [0.25, 0.25]
 
 
+def test_run_automation_invalid_events(monkeypatch):
+    """run_automation should handle missing or invalid events list."""
+    monkeypatch.setattr(auto.time, "sleep", lambda s: None)
+    result = auto.run_automation([{"name": "bad", "events": None}], "bad", step_delay=0)
+    assert "Invalid event list" in result
+
+
 # --- Tests for Step-based Automations ---
 
 @patch('automation_sequences.pyautogui', new_callable=MagicMock)


### PR DESCRIPTION
## Summary
- ensure `run_automation` checks the events list before playback
- test automation playback with missing events

## Testing
- `flake8 .` *(fails: various style errors)*
- `PYTHONPATH=. pytest -q tests/test_automation_sequences.py::test_run_automation_invalid_events -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_6845c99eebb8832689a808795d17db4e