### PR TITLE
Add get_agent_names method

### DIFF
--- a/tab_agents.py
+++ b/tab_agents.py
@@ -612,3 +612,7 @@ class AgentsTab(QWidget):
         app.change_tab(9, app.nav_buttons.get("docs"))
         if "Agents Help" in app.docs_tab.doc_map:
             app.docs_tab.selector.setCurrentText("Agents Help")
+
+    def get_agent_names(self):
+        """Return a list of all configured agent names."""
+        return list(getattr(self.parent_app, "agents_data", {}).keys())

--- a/tests/test_agents_get_agent_names.py
+++ b/tests/test_agents_get_agent_names.py
@@ -1,0 +1,19 @@
+import os
+from PyQt5.QtWidgets import QApplication
+import tab_agents
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+class DummyApp:
+    def __init__(self):
+        self.agents_data = {"AgentA": {}, "AgentB": {}}
+        self.nav_buttons = {}
+        self.docs_tab = type("Dummy", (), {"doc_map": {}, "selector": None})()
+    def change_tab(self, *args, **kwargs):
+        pass
+
+def test_get_agent_names():
+    app_instance = QApplication.instance() or QApplication([])
+    tab = tab_agents.AgentsTab(DummyApp())
+    assert sorted(tab.get_agent_names()) == ["AgentA", "AgentB"]
+    app_instance.quit()


### PR DESCRIPTION
## Summary
- expose agent names via `AgentsTab.get_agent_names`
- test the new helper

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_6845ce52f8ec8326a4687c3ffa8824f1