### PR TITLE
Add SetVariable automation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Cerebro offers a rich set of features to enhance your interaction with AI models
 * **Tool Status Indicators:** The Tools tab now shows a status column with color-coded icons so you can easily see if a tool is enabled or disabled.
 *   **Thinking Mode:** Enable agents to iteratively generate a series of thoughts before producing a final answer. (Details: [Application Tabs - Agents](docs/app_tabs.md#agents-tab))
 *   **Automations:** Record and replay desktop actions (mouse and keyboard sequences). (Details: [Application Tabs - Automations](docs/app_tabs.md#automations-tab))
+*   **SetVariable Step:** Step-based automations can store custom variables using a dedicated step.
 * **Task Scheduling:** Schedule prompts for agents to run at specific times, with recurring options (daily/weekly/monthly or custom minutes), drag-and-drop reordering, duplication, undo after deletion, inline editing, bulk editing, and reusable templates. (Details: [Application Tabs - Tasks](docs/app_tabs.md#tasks-tab))
 * * **Task Progress Indicators:** View elapsed time and an ETA for scheduled tasks.
 *   **Failure Details:** When tasks fail or are put on hold the reason, a link to more information, and suggested actions appear in the task list.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -32,6 +32,7 @@ Cerebro is a multi-agent AI application with a rich set of features:
 - **Agent Management:** Configure multiple AI agents with different models, roles (Coordinator, Assistant, Specialist), and capabilities.
 - **Tool Integration:** Extend agent capabilities with custom tools.
 - **Task Automation:** Record desktop automations and schedule tasks for agents with recurring options and templates, inline editing, bulk changes, drag-and-drop reordering, duplication, and undo for deleted tasks.
+- **SetVariable Step:** Step-based automations can store custom variables using a dedicated `SetVariable` step.
 - **Failure Details:** When a task cannot run, the task entry shows the reason along with a link to more information and any suggested actions.
 Reasoning for this resolution:
 - **Workflows:** Define complex, multi-agent workflows.

--- a/tab_automations.py
+++ b/tab_automations.py
@@ -27,6 +27,7 @@ from automation_sequences import (
     STEP_TYPE_ELSE,
     STEP_TYPE_END_IF,
     STEP_TYPE_MOUSE_DRAG,
+    STEP_TYPE_SET_VARIABLE,
     load_step_automations,
     save_step_automations,
     run_step_automation,
@@ -189,6 +190,7 @@ class AutomationsTab(QWidget):
             STEP_TYPE_KEYBOARD_INPUT,
             STEP_TYPE_WAIT,
             STEP_TYPE_ASK_AGENT,
+            STEP_TYPE_SET_VARIABLE,
             STEP_TYPE_LOOP_START,
             STEP_TYPE_LOOP_END,
             STEP_TYPE_IF_CONDITION,
@@ -428,6 +430,8 @@ class AutomationsTab(QWidget):
             elif "condition" in params:
                 return f"{step_type} (condition:'{params.get('condition','').strip()}')" # Added strip
             return f"{step_type} (count:1)" # Default
+        elif step_type == STEP_TYPE_SET_VARIABLE:
+            return f"{step_type} ({params.get('name','')}: {params.get('value','')})"
         elif step_type == STEP_TYPE_IF_CONDITION:
             return f"{STEP_TYPE_IF_CONDITION} (condition:'{params.get('condition','true').strip()}')" # Default to true, added strip
         elif step_type == STEP_TYPE_ELSE:
@@ -469,6 +473,8 @@ class AutomationsTab(QWidget):
                 "prompt": "Please provide input.",
                 "send_screenshot": False
             }
+        elif step_type_name == STEP_TYPE_SET_VARIABLE:
+            default_params = {"name": "var", "value": ""}
         elif step_type_name == STEP_TYPE_LOOP_START:
             default_params = {"count": 1}
         elif step_type_name == STEP_TYPE_IF_CONDITION:
@@ -575,6 +581,12 @@ class AutomationsTab(QWidget):
             self.current_param_widgets["duration"].setValue(params.get("duration", 1.0))
             self.param_form_layout.addRow("Duration (s):", self.current_param_widgets["duration"])
 
+        elif step_type == STEP_TYPE_SET_VARIABLE:
+            self.current_param_widgets["name"] = QLineEdit(params.get("name", ""))
+            self.param_form_layout.addRow("Name:", self.current_param_widgets["name"])
+            self.current_param_widgets["value"] = QLineEdit(str(params.get("value", "")))
+            self.param_form_layout.addRow("Value:", self.current_param_widgets["value"])
+
         elif step_type == STEP_TYPE_ASK_AGENT:
             # Agent Selection
             self.current_param_widgets["agent_name"] = QComboBox()
@@ -675,6 +687,9 @@ class AutomationsTab(QWidget):
                 new_params["keys"] = self.current_param_widgets["keys"].text()
             elif step_type == STEP_TYPE_WAIT:
                 new_params["duration"] = self.current_param_widgets["duration"].value()
+            elif step_type == STEP_TYPE_SET_VARIABLE:
+                new_params["name"] = self.current_param_widgets["name"].text()
+                new_params["value"] = self.current_param_widgets["value"].text()
             elif step_type == STEP_TYPE_ASK_AGENT:
                 agent_name_selected = self.current_param_widgets["agent_name"].currentText()
                 # Handle "(No Agent)" placeholder if used

--- a/tests/test_automation_sequences_step_based.py
+++ b/tests/test_automation_sequences_step_based.py
@@ -14,6 +14,7 @@ from automation_sequences import (
     STEP_TYPE_MOUSE_CLICK, STEP_TYPE_KEYBOARD_INPUT, STEP_TYPE_WAIT,
     STEP_TYPE_ASK_AGENT, STEP_TYPE_LOOP_START, STEP_TYPE_LOOP_END,
     STEP_TYPE_IF_CONDITION, STEP_TYPE_ELSE, STEP_TYPE_END_IF,
+    STEP_TYPE_SET_VARIABLE,
     STEP_AUTOMATIONS_FILE,
     DEFAULT_EXECUTION_CONTEXT,
     PYAUTOGUI_SPECIAL_KEYS # For testing keyboard input
@@ -38,6 +39,10 @@ class TestStepBasedHelperFunctions(unittest.TestCase):
     def test_is_valid_step_wait(self):
         self.assertTrue(is_valid_step({"type": STEP_TYPE_WAIT, "params": {"duration": 1.5}}))
         self.assertFalse(is_valid_step({"type": STEP_TYPE_WAIT, "params": {"duration": "bad"}}))
+
+    def test_is_valid_step_set_variable(self):
+        self.assertTrue(is_valid_step({"type": STEP_TYPE_SET_VARIABLE, "params": {"name": "x", "value": "1"}}))
+        self.assertFalse(is_valid_step({"type": STEP_TYPE_SET_VARIABLE, "params": {"value": "1"}}))
 
     def test_is_valid_step_ask_agent_old_params(self): # Renamed to keep old tests for basic prompt check
         self.assertTrue(is_valid_step({"type": STEP_TYPE_ASK_AGENT, "params": {"prompt": "Test?"}}))
@@ -209,6 +214,12 @@ class TestRunStepAutomation(unittest.TestCase):
         context = run_step_automation(steps)
         self.mock_time_sleep.assert_called_once_with(2.5)
         self.assertEqual(context['status'], 'completed')
+
+    def test_run_set_variable(self):
+        steps = [create_step(STEP_TYPE_SET_VARIABLE, {"name": "foo", "value": "bar"})]
+        context = run_step_automation(steps)
+        self.assertEqual(context['status'], 'completed')
+        self.assertEqual(context['variables'].get('foo'), 'bar')
 
     def test_run_ask_agent(self):
         steps = [create_step(STEP_TYPE_ASK_AGENT, {"prompt": "User, do this.", "screenshot_path": "img.png"})]


### PR DESCRIPTION
## Summary
- add new `SetVariable` step type
- store custom variables in automation context
- support editing SetVariable steps in the Automations tab UI
- document the new step in the README and user guide
- test SetVariable validation and execution

## Testing
- `flake8 .`
- `PYTHONPATH=. pytest -q` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_6845ceeaa6888326864007bd42726066