### PR TITLE
Add EndElf step type

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -33,6 +33,7 @@ Cerebro is a multi-agent AI application with a rich set of features:
 - **Tool Integration:** Extend agent capabilities with custom tools.
 - **Task Automation:** Record desktop automations and schedule tasks for agents with recurring options and templates, inline editing, bulk changes, drag-and-drop reordering, duplication, and undo for deleted tasks.
 - **SetVariable Step:** Step-based automations can store custom variables using a dedicated `SetVariable` step.
+- **EndElf Step:** Use `EndElf` to close an `IfCondition` block when building step-based automations.
 - **Failure Details:** When a task cannot run, the task entry shows the reason along with a link to more information and any suggested actions.
 Reasoning for this resolution:
 - **Workflows:** Define complex, multi-agent workflows.

--- a/tab_automations.py
+++ b/tab_automations.py
@@ -26,6 +26,7 @@ from automation_sequences import (
     STEP_TYPE_IF_CONDITION,
     STEP_TYPE_ELSE,
     STEP_TYPE_END_IF,
+    STEP_TYPE_END_ELF,
     STEP_TYPE_MOUSE_DRAG,
     STEP_TYPE_SET_VARIABLE,
     load_step_automations,
@@ -195,7 +196,8 @@ class AutomationsTab(QWidget):
             STEP_TYPE_LOOP_END,
             STEP_TYPE_IF_CONDITION,
             STEP_TYPE_ELSE,
-            STEP_TYPE_END_IF
+            STEP_TYPE_END_IF,
+            STEP_TYPE_END_ELF
         ]
         for step_type_name in self.step_types:
             self.available_steps_list.addItem(QListWidgetItem(step_type_name))
@@ -440,12 +442,14 @@ class AutomationsTab(QWidget):
             return STEP_TYPE_ELSE
         elif step_type == STEP_TYPE_END_IF:
             return STEP_TYPE_END_IF
+        elif step_type == STEP_TYPE_END_ELF:
+            return STEP_TYPE_END_ELF
         elif step_type == STEP_TYPE_LOOP_END: # Explicitly handle LoopEnd if not covered by generic
             return STEP_TYPE_LOOP_END
         elif step_type == STEP_TYPE_MOUSE_DRAG:
             return f"{step_type} (start:({params.get('start_x',0)},{params.get('start_y',0)}), end:({params.get('end_x',0)},{params.get('end_y',0)}))"
         # Fallback for any other types that might be simple
-        elif step_type in [STEP_TYPE_LOOP_END, STEP_TYPE_ELSE, STEP_TYPE_END_IF]: # Redundant but safe
+        elif step_type in [STEP_TYPE_LOOP_END, STEP_TYPE_ELSE, STEP_TYPE_END_IF, STEP_TYPE_END_ELF]: # Redundant but safe
             return step_type
         return f"Unknown Step: {step_type}"
 
@@ -665,7 +669,7 @@ class AutomationsTab(QWidget):
             # Show current coordinates within the parameter editor
             self.param_form_layout.addRow("Current Position:", self.coordinates_label)
 
-        elif step_type in [STEP_TYPE_LOOP_END, STEP_TYPE_ELSE, STEP_TYPE_END_IF]:
+        elif step_type in [STEP_TYPE_LOOP_END, STEP_TYPE_ELSE, STEP_TYPE_END_IF, STEP_TYPE_END_ELF]:
             self.param_form_layout.addRow(QLabel(f"{step_type} (No parameters)"))
             self.apply_param_changes_btn.setVisible(False)
 

--- a/tests/test_automation_sequences_step_based.py
+++ b/tests/test_automation_sequences_step_based.py
@@ -13,7 +13,7 @@ from automation_sequences import (
     run_step_automation,
     STEP_TYPE_MOUSE_CLICK, STEP_TYPE_KEYBOARD_INPUT, STEP_TYPE_WAIT,
     STEP_TYPE_ASK_AGENT, STEP_TYPE_LOOP_START, STEP_TYPE_LOOP_END,
-    STEP_TYPE_IF_CONDITION, STEP_TYPE_ELSE, STEP_TYPE_END_IF,
+    STEP_TYPE_IF_CONDITION, STEP_TYPE_ELSE, STEP_TYPE_END_IF, STEP_TYPE_END_ELF,
     STEP_TYPE_SET_VARIABLE,
     STEP_AUTOMATIONS_FILE,
     DEFAULT_EXECUTION_CONTEXT,
@@ -74,6 +74,7 @@ class TestStepBasedHelperFunctions(unittest.TestCase):
         self.assertFalse(is_valid_step({"type": STEP_TYPE_IF_CONDITION, "params": {}})) # Missing condition
         self.assertTrue(is_valid_step({"type": STEP_TYPE_ELSE, "params": {}}))
         self.assertTrue(is_valid_step({"type": STEP_TYPE_END_IF, "params": {}}))
+        self.assertTrue(is_valid_step({"type": STEP_TYPE_END_ELF, "params": {}}))
 
     def test_is_valid_step_invalid_structure(self):
         self.assertFalse(is_valid_step(None))
@@ -348,6 +349,16 @@ class TestRunStepAutomation(unittest.TestCase):
         ]
         context = run_step_automation(steps)
         self.mock_pyautogui.click.assert_called_once_with(x=3,y=3,button="middle")
+        self.assertEqual(context['status'], 'completed')
+
+    def test_run_if_true_with_endelf(self):
+        steps = [
+            create_step(STEP_TYPE_IF_CONDITION, {"condition": "true"}),
+            create_step(STEP_TYPE_MOUSE_CLICK, {"x": 4, "y": 4, "button": "left"}),
+            create_step(STEP_TYPE_END_ELF, {})
+        ]
+        context = run_step_automation(steps)
+        self.mock_pyautogui.click.assert_called_once_with(x=4, y=4, button="left")
         self.assertEqual(context['status'], 'completed')
 
     def test_run_loop_with_if_and_ask_agent(self):


### PR DESCRIPTION
## Summary
- add `EndElf` step type to automation sequences
- allow 'EndElf' in automation UI
- validate EndElf in tests and docs

## Testing
- `flake8 .` *(fails: E301, E305, F401, etc.)*
- `pytest -q` *(fails: Aborted - PyQt5 requires display server)*

------
https://chatgpt.com/codex/tasks/task_e_6845d8f34594832692fed267604f0c36